### PR TITLE
 hook LootChest plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,8 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-.idea
-target
+.idea/
+target/
 
 *.json
 TODO.txt

--- a/README.md
+++ b/README.md
@@ -4,3 +4,25 @@ A spigot plugin for easily creating and customizing mazes in Minecraft. With a W
 
 For downloads & more information:
 <https://www.spigotmc.org/resources/tangled-maze.59284/>
+
+
+## Features
+- Building mazes from rectangles, circles and triangles
+- Maze generation that adapts to height differences in the terrain
+- Highly customizable maze settings for sizes of paths, walls and composition of building blocks
+- Ability to set multiple entrances and exits for a maze
+- Possibility to add a roof and change the floor of the maze
+- Maze solving feature to see the path connecting all exits in a maze
+
+## Development
+
+To be able to compile the plugin with the [LootChest](https://www.spigotmc.org/resources/lootchest.61564/) dependency, you need to install the LootChest jar file in your local maven repository.
+You can do this by running the following command in the directory where the LootChest.jar file is located:
+```shell
+mvn install:install-file -Dfile=<path/to/LootChest.jar> -DgroupId=fr.black_eyes.lootchest -DartifactId=LootChest -Dversion=2.4.0 -Dpackaging=jar
+```
+
+And - I have no slightest idea why - the library HoloEasy compiled inside LootChest.jar was not recognized until I ran:
+```shell
+mvn install:install-file -Dfile=<path/to/LootChest.jar> -DgroupId=org.holoeasy -DartifactId=holoeasy -Dversion=3.1.1 -Dpackaging=jar
+```

--- a/pom.xml
+++ b/pom.xml
@@ -76,5 +76,11 @@
 			<version>5.8.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>fr.black_eyes.lootchest</groupId>
+			<artifactId>LootChest</artifactId>
+			<version>2.4.0</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/me/gorgeousone/tangledmaze/SessionHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/SessionHandler.java
@@ -86,8 +86,9 @@ public class SessionHandler {
 		return mazeBackups.containsKey(maze) && mazeBackups.get(maze).getMazeMap() != null;
 	}
 	
-	public void backupMaze(Clip maze, MazeSettings settings) {
-		mazeBackups.computeIfAbsent(maze, backup -> new MazeBackup(maze, settings));
+	public MazeBackup backupMaze(Clip maze, MazeSettings settings) {
+		return mazeBackups.computeIfAbsent(maze, backup -> new MazeBackup(maze, settings));
+
 	}
 	
 	public MazeBackup getBackup(Clip maze) {

--- a/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
@@ -1,5 +1,6 @@
 package me.gorgeousone.tangledmaze;
 
+import fr.black_eyes.lootchest.Main;
 import me.gorgeousone.tangledmaze.cmdframework.command.ParentCommand;
 import me.gorgeousone.tangledmaze.cmdframework.handler.CommandHandler;
 import me.gorgeousone.tangledmaze.command.AddClipCommand;
@@ -24,6 +25,7 @@ import me.gorgeousone.tangledmaze.listener.ChangeWorldListener;
 import me.gorgeousone.tangledmaze.listener.ClickListener;
 import me.gorgeousone.tangledmaze.listener.PlayerQuitListener;
 import me.gorgeousone.tangledmaze.listener.UiListener;
+import me.gorgeousone.tangledmaze.loot.LootHandler;
 import me.gorgeousone.tangledmaze.menu.UiHandler;
 import me.gorgeousone.tangledmaze.render.RenderHandler;
 import me.gorgeousone.tangledmaze.tool.ToolHandler;
@@ -37,24 +39,25 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class TangledMazePlugin extends JavaPlugin {
-	
+
 	private static final int resourceId = 59284;
 	private static final String resourceName = "tangled-maze-maze-generator";
 	private static final String updateInfoUrl = "https://pastebin.com/raw/BRJfXpPu";
-	
+
 	private static TangledMazePlugin instance;
 	private SessionHandler sessionHandler;
 	private ToolHandler toolHandler;
 	private RenderHandler renderHandler;
 	private BuildHandler buildHandler;
 	private UiHandler uiHandler;
+	private LootHandler lootHandler;
 	private ConfigSettings settings;
 	private ParentCommand mazeCmd;
-	
+
 	@Override
 	public void onEnable() {
 		instance = this;
-		
+
 		configureAPI();
 		sessionHandler = new SessionHandler();
 		toolHandler = new ToolHandler(sessionHandler);
@@ -64,46 +67,46 @@ public final class TangledMazePlugin extends JavaPlugin {
 
 		registerListeners();
 		registerCommands();
-		
+
 		settings = new ConfigSettings(this);
 		reload();
 	}
-	
+
 	@Override
 	public void onDisable() {
 		renderHandler.disable();
 		sessionHandler.disable();
 		toolHandler.disable();
 	}
-	
+
 	public void reload() {
 		loadConfigSettings();
 		loadLanguage();
 		checkForUpdates();
 	}
-	
+
 	/**
 	 * Configures settings needed if the plugin jar is used as API
 	 */
 	public static void configureAPI() {
 		BlockType.configureVersion(VersionUtil.IS_LEGACY_SERVER);
 	}
-	
+
 	/**
 	 * For API use only
 	 */
 	public static TangledMazePlugin getInstance() {
 		return instance;
 	}
-	
+
 	public SessionHandler getSessionHandler() {
 		return sessionHandler;
 	}
-	
+
 	public ParentCommand getMazeCommand() {
 		return mazeCmd;
 	}
-	
+
 	void registerListeners() {
 		PluginManager manager = Bukkit.getPluginManager();
 		manager.registerEvents(renderHandler, this);
@@ -113,13 +116,13 @@ public final class TangledMazePlugin extends JavaPlugin {
 		manager.registerEvents(new ChangeWorldListener(toolHandler, renderHandler), this);
 		manager.registerEvents(new UiListener(uiHandler), this);
 	}
-	
+
 	private void registerCommands() {
 		mazeCmd = new ParentCommand("tangledmaze");
 		mazeCmd.addAlias("maze");
 		mazeCmd.addAlias("tm");
 		mazeCmd.setPermission(Constants.BUILD_PERM);
-		
+
 		mazeCmd.addChild(new HelpCommand());
 		mazeCmd.addChild(new GetWandCommand());
 		mazeCmd.addChild(new ReloadCommand(this));
@@ -133,29 +136,38 @@ public final class TangledMazePlugin extends JavaPlugin {
 		mazeCmd.addChild(new UnbuildMazeCommand(sessionHandler, buildHandler));
 		mazeCmd.addChild(new TeleportCommand(sessionHandler, renderHandler));
 		mazeCmd.addChild(new SolveMazeCommand(sessionHandler, renderHandler));
-		
+
 		CommandHandler cmdHandler = new CommandHandler(this);
 		cmdHandler.registerCommand(mazeCmd);
 	}
-	
+
 	private void loadConfigSettings() {
 		reloadConfig();
 		settings.addVersionDefaults(getConfig(), VersionUtil.IS_LEGACY_SERVER);
 		getConfig().options().copyDefaults(true);
 		saveConfig();
 		settings.loadSettings(getConfig());
-		
+
 		String versionString = VersionUtil.IS_LEGACY_SERVER ? "legacy" : "aquatic";
 		Constants.loadMaterials(ConfigUtil.loadConfig("materials-" + versionString, this));
 		MaterialUtil.load();
 	}
-	
+
 	private void loadLanguage() {
 		Message.loadLanguage(ConfigUtil.loadConfig("language", this));
 		uiHandler.reloadLanguage();
 	}
-	
+
 	private void checkForUpdates() {
 		new UpdateCheck(this, resourceId, resourceName, updateInfoUrl).run();
+	}
+
+	private void hookLootChest() {
+		if (Bukkit.getServer().getPluginManager().getPlugin("LootChest") != null) {
+			Main lootChestPlugin = Main.getInstance();
+			lootHandler = new LootHandler(lootChestPlugin);
+		} else {
+			
+		}
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
@@ -8,7 +8,9 @@ import me.gorgeousone.tangledmaze.command.BuildMazeCommand;
 import me.gorgeousone.tangledmaze.command.CutClipCommand;
 import me.gorgeousone.tangledmaze.command.GetWandCommand;
 import me.gorgeousone.tangledmaze.command.HelpCommand;
-import me.gorgeousone.tangledmaze.command.SpawnLootCommand;
+import me.gorgeousone.tangledmaze.loot.LootRemoveCommand;
+import me.gorgeousone.tangledmaze.loot.LootRespawnCommand;
+import me.gorgeousone.tangledmaze.loot.LootSpawnCommand;
 import me.gorgeousone.tangledmaze.command.ReloadCommand;
 import me.gorgeousone.tangledmaze.command.SettingsCommand;
 import me.gorgeousone.tangledmaze.command.SolveMazeCommand;
@@ -136,12 +138,18 @@ public final class TangledMazePlugin extends JavaPlugin {
 		mazeCmd.addChild(new CutClipCommand(sessionHandler, toolHandler));
 		mazeCmd.addChild(new UndoCommand(sessionHandler));
 		mazeCmd.addChild(new SettingsCommand(sessionHandler));
-		mazeCmd.addChild(new BuildMazeCommand(sessionHandler, buildHandler, toolHandler, lootHandler));
+		mazeCmd.addChild(new BuildMazeCommand(sessionHandler, buildHandler, toolHandler));
 		mazeCmd.addChild(new UnbuildMazeCommand(sessionHandler, buildHandler));
 		mazeCmd.addChild(new TeleportCommand(sessionHandler, renderHandler));
 		mazeCmd.addChild(new SolveMazeCommand(sessionHandler, renderHandler));
 
-		mazeCmd.addChild(new SpawnLootCommand(sessionHandler, lootHandler, lootHandler != null));
+		boolean isLootAvailable = lootHandler != null;
+		ParentCommand lootCmd = new ParentCommand("loot");
+		lootCmd.addChild(new LootSpawnCommand(sessionHandler, lootHandler, isLootAvailable));
+		lootCmd.addChild(new LootRespawnCommand(sessionHandler, lootHandler, isLootAvailable));
+		lootCmd.addChild(new LootRemoveCommand(sessionHandler, lootHandler, isLootAvailable));
+		mazeCmd.addChild(lootCmd);
+
 		CommandHandler cmdHandler = new CommandHandler(this);
 		cmdHandler.registerCommand(mazeCmd);
 	}
@@ -171,7 +179,7 @@ public final class TangledMazePlugin extends JavaPlugin {
 		Logger logger = Bukkit.getLogger();
 		if (Bukkit.getServer().getPluginManager().getPlugin("LootChest") != null) {
 			Main lootChestPlugin = Main.getInstance();
-			lootHandler = new LootHandler(sessionHandler, lootChestPlugin);
+			lootHandler = new LootHandler(lootChestPlugin);
 			logger.info("LootChest detected");
 		} else {
 			logger.info("LootChest not found");

--- a/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
@@ -29,6 +29,7 @@ import me.gorgeousone.tangledmaze.listener.ClickListener;
 import me.gorgeousone.tangledmaze.listener.PlayerQuitListener;
 import me.gorgeousone.tangledmaze.listener.UiListener;
 import me.gorgeousone.tangledmaze.loot.LootHandler;
+import me.gorgeousone.tangledmaze.loot.UnbuildListener;
 import me.gorgeousone.tangledmaze.menu.UiHandler;
 import me.gorgeousone.tangledmaze.render.RenderHandler;
 import me.gorgeousone.tangledmaze.tool.ToolHandler;
@@ -121,6 +122,7 @@ public final class TangledMazePlugin extends JavaPlugin {
 		manager.registerEvents(new BlockChangeListener(this, sessionHandler), this);
 		manager.registerEvents(new ChangeWorldListener(toolHandler, renderHandler), this);
 		manager.registerEvents(new UiListener(uiHandler), this);
+		manager.registerEvents(new UnbuildListener(lootHandler), this);
 	}
 
 	private void registerCommands() {
@@ -179,10 +181,11 @@ public final class TangledMazePlugin extends JavaPlugin {
 		Logger logger = Bukkit.getLogger();
 		if (Bukkit.getServer().getPluginManager().getPlugin("LootChest") != null) {
 			Main lootChestPlugin = Main.getInstance();
-			lootHandler = new LootHandler(lootChestPlugin);
-			logger.info("LootChest detected");
+			lootHandler = new LootHandler(sessionHandler, lootChestPlugin);
+			logger.info("Successfully detected LootChest plugin for spawning loot chests.");
 		} else {
-			logger.info("LootChest not found");
+			logger.info("LootChest plugin not detected. Loot chests can't be used.");
+			logger.info("Download available at: https://www.spigotmc.org/resources/lootchest.61564/");
 		}
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
@@ -8,6 +8,7 @@ import me.gorgeousone.tangledmaze.command.BuildMazeCommand;
 import me.gorgeousone.tangledmaze.command.CutClipCommand;
 import me.gorgeousone.tangledmaze.command.GetWandCommand;
 import me.gorgeousone.tangledmaze.command.HelpCommand;
+import me.gorgeousone.tangledmaze.command.SpawnLootCommand;
 import me.gorgeousone.tangledmaze.command.ReloadCommand;
 import me.gorgeousone.tangledmaze.command.SettingsCommand;
 import me.gorgeousone.tangledmaze.command.SolveMazeCommand;
@@ -38,6 +39,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.logging.Logger;
+
 public final class TangledMazePlugin extends JavaPlugin {
 
 	private static final int resourceId = 59284;
@@ -65,6 +68,7 @@ public final class TangledMazePlugin extends JavaPlugin {
 		buildHandler = new BuildHandler(this, sessionHandler);
 		uiHandler = new UiHandler(toolHandler);
 
+		hookLootChestPlugin();
 		registerListeners();
 		registerCommands();
 
@@ -132,11 +136,12 @@ public final class TangledMazePlugin extends JavaPlugin {
 		mazeCmd.addChild(new CutClipCommand(sessionHandler, toolHandler));
 		mazeCmd.addChild(new UndoCommand(sessionHandler));
 		mazeCmd.addChild(new SettingsCommand(sessionHandler));
-		mazeCmd.addChild(new BuildMazeCommand(sessionHandler, buildHandler, toolHandler));
+		mazeCmd.addChild(new BuildMazeCommand(sessionHandler, buildHandler, toolHandler, lootHandler));
 		mazeCmd.addChild(new UnbuildMazeCommand(sessionHandler, buildHandler));
 		mazeCmd.addChild(new TeleportCommand(sessionHandler, renderHandler));
 		mazeCmd.addChild(new SolveMazeCommand(sessionHandler, renderHandler));
 
+		mazeCmd.addChild(new SpawnLootCommand(sessionHandler, lootHandler, lootHandler != null));
 		CommandHandler cmdHandler = new CommandHandler(this);
 		cmdHandler.registerCommand(mazeCmd);
 	}
@@ -162,12 +167,14 @@ public final class TangledMazePlugin extends JavaPlugin {
 		new UpdateCheck(this, resourceId, resourceName, updateInfoUrl).run();
 	}
 
-	private void hookLootChest() {
+	private void hookLootChestPlugin() {
+		Logger logger = Bukkit.getLogger();
 		if (Bukkit.getServer().getPluginManager().getPlugin("LootChest") != null) {
 			Main lootChestPlugin = Main.getInstance();
-			lootHandler = new LootHandler(lootChestPlugin);
+			lootHandler = new LootHandler(sessionHandler, lootChestPlugin);
+			logger.info("LootChest detected");
 		} else {
-			
+			logger.info("LootChest not found");
 		}
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/cmdframework/argument/ArgValue.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/cmdframework/argument/ArgValue.java
@@ -4,7 +4,7 @@ import org.bukkit.ChatColor;
 
 public class ArgValue {
 	
-	private static final String exceptionText = ChatColor.RED + "'%value%' is not a %type%.";
+	private static final String EXCEPTION_TEXT = ChatColor.RED + "'%value%' is not a %type%.";
 	
 	private int intVal;
 	private double decimalVal;
@@ -51,7 +51,7 @@ public class ArgValue {
 					break;
 			}
 		} catch (Exception e) {
-			throw new IllegalArgumentException(exceptionText.replace("%value%", value).replace("%type%", type.simpleName()));
+			throw new IllegalArgumentException(EXCEPTION_TEXT.replace("%value%", value).replace("%type%", type.simpleName()));
 		}
 	}
 	

--- a/src/main/java/me/gorgeousone/tangledmaze/command/BuildMazeCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/command/BuildMazeCommand.java
@@ -57,14 +57,9 @@ public class BuildMazeCommand extends ArgCommand {
 			return;
 		}
 		MazeSettings settings = sessionHandler.getSettings(playerId);
-		MazePart mazePart = MazePart.WALLS;
-		
-		if (usedFlags.contains("floor")) {
-			mazePart = MazePart.FLOOR;
-		} else if (usedFlags.contains("roof")) {
-			mazePart = MazePart.ROOF;
-		}
-		if (argValues.size() != 0) {
+		MazePart mazePart = getMazePart(usedFlags);
+
+		if (!argValues.isEmpty()) {
 			try {
 				BlockPalette palette = deserializeBlockPalette(argValues);
 				settings.setPalette(mazePart, palette);
@@ -86,7 +81,18 @@ public class BuildMazeCommand extends ArgCommand {
 		maze.setEditable(false);
 		toolHandler.resetClipTool(playerId);
 	}
-	
+
+	private MazePart getMazePart(Set<String> usedFlags) {
+		if (usedFlags.contains("floor")) {
+			return MazePart.FLOOR;
+		} else if (usedFlags.contains("roof")) {
+			return MazePart.ROOF;
+		} else if (usedFlags.contains("loot")) {
+			return MazePart.LOOT_CHESTS;
+		}
+		return MazePart.WALLS;
+	}
+
 	/**
 	 * Converts a list of material strings in the format "count(optional)*material:subId(optional)" into a BlockPalette.
 	 * @param stringArgs the list of strings provided by the command sender

--- a/src/main/java/me/gorgeousone/tangledmaze/command/SpawnLootCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/command/SpawnLootCommand.java
@@ -1,163 +1,161 @@
 package me.gorgeousone.tangledmaze.command;
 
+import fr.black_eyes.lootchest.Main;
 import me.gorgeousone.tangledmaze.SessionHandler;
 import me.gorgeousone.tangledmaze.clip.Clip;
+import me.gorgeousone.tangledmaze.cmdframework.argument.ArgType;
 import me.gorgeousone.tangledmaze.cmdframework.argument.ArgValue;
+import me.gorgeousone.tangledmaze.cmdframework.argument.Argument;
 import me.gorgeousone.tangledmaze.cmdframework.command.ArgCommand;
 import me.gorgeousone.tangledmaze.data.Message;
-import me.gorgeousone.tangledmaze.generation.MazeMap;
-import me.gorgeousone.tangledmaze.generation.building.BlockPalette;
-import me.gorgeousone.tangledmaze.generation.building.BuildHandler;
 import me.gorgeousone.tangledmaze.loot.LootHandler;
-import me.gorgeousone.tangledmaze.maze.MazePart;
-import me.gorgeousone.tangledmaze.maze.MazeSettings;
-import me.gorgeousone.tangledmaze.tool.ToolHandler;
+import me.gorgeousone.tangledmaze.maze.MazeBackup;
 import me.gorgeousone.tangledmaze.util.MaterialUtil;
 import me.gorgeousone.tangledmaze.util.MathUtil;
-import me.gorgeousone.tangledmaze.util.blocktype.BlockType;
 import me.gorgeousone.tangledmaze.util.text.Placeholder;
 import me.gorgeousone.tangledmaze.util.text.TextException;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-/**
- * The command to build the walls, floor or roof of a maze.
- */
-public class BuildMazeCommand extends ArgCommand {
-	
+public class SpawnLootCommand extends ArgCommand {
+
+	private static final String EXCEPTION_TEXT = ChatColor.RED + "'%type%' is can only be %value%.";
+
 	private final SessionHandler sessionHandler;
-	private final BuildHandler buildHandler;
-	private final ToolHandler toolHandler;
 	private final LootHandler lootHandler;
+	private final boolean isAvailable;
 
-	
-	public BuildMazeCommand(SessionHandler sessionHandler,
-	                        BuildHandler buildHandler, ToolHandler toolHandler, LootHandler lootHandler) {
-		super("build");
-		addAlias("b");
-		addFlag("floor");
-		addFlag("roof");
-		addFlag("hollow");
+	public SpawnLootCommand(SessionHandler sessionHandler, LootHandler lootHandler, boolean isAvailable) {
+		super("loot");
+		addArg(new Argument("action", ArgType.STRING, "spawn", "despawn"));
 
-		this.toolHandler = toolHandler;
 		this.sessionHandler = sessionHandler;
-		this.buildHandler = buildHandler;
 		this.lootHandler = lootHandler;
+		this.isAvailable = isAvailable;
 	}
 
 	@Override
 	protected void executeArgs(CommandSender sender, List<ArgValue> argValues, Set<String> usedFlags) {
+		if (!isAvailable) {
+			Message.ERROR_INVALID_SETTING.sendTo(sender, new Placeholder("setting", "LootChest plugin not loaded"));
+			return;
+		}
 		UUID playerId = getSenderId(sender);
 		Clip maze = sessionHandler.getMazeClip(playerId);
-		
+
 		if (null == maze) {
 			Message.ERROR_MAZE_MISSING.sendTo(sender);
 			return;
 		}
-		if (maze.getExits().isEmpty()) {
-			Message.ERROR_EXIT_MISSING.sendTo(sender);
+		if (!sessionHandler.isBuilt(maze)) {
+			Message.INFO_MAZE_NOT_BUILT.sendTo(sender);
 			return;
 		}
-		MazeSettings settings = sessionHandler.getSettings(playerId);
-		MazePart mazePart = getMazePart(usedFlags);
-
-		if (!argValues.isEmpty()) {
-			try {
-				BlockPalette palette = deserializeBlockPalette(argValues);
-				settings.setPalette(mazePart, palette);
-			} catch (TextException e) {
-				e.sendTextTo(sender);
-				return;
-			}
-		}
-		boolean areWallsHollow = usedFlags.contains("hollow");
+		MazeBackup backup = sessionHandler.getBackup(maze);
+		boolean isSpawn;
 
 		try {
-			setAsync(sender);
-			buildHandler.buildMaze(maze, settings, mazePart, areWallsHollow, () -> finishAsync(sender));
-		} catch (TextException e) {
-			e.sendTextTo(sender);
-			finishAsync(sender);
+			isSpawn = getSpawnAction(argValues.get(0).get());
+		} catch (IllegalArgumentException e) {
+			sender.sendMessage(e.getMessage());
 			return;
 		}
-		maze.setEditable(false);
-		toolHandler.resetClipTool(playerId);
+		if (argValues.size() < 2) {
+			sender.sendMessage("please specify chests to place (times*chestName)");
+			return;
+		}
+		Map<String, Integer> chestAmounts;
+		argValues.remove(0);
+
+		try {
+			chestAmounts = deserializeLootChestPrefabs(argValues);
+			lootHandler.placeChests(backup.getMazeMap(), chestAmounts);
+		} catch (TextException e) {
+			e.sendTextTo(sender);
+		}
 	}
 
-	private MazePart getMazePart(Set<String> usedFlags) {
-		if (usedFlags.contains("floor")) {
-			return MazePart.FLOOR;
-		} else if (usedFlags.contains("roof")) {
-			return MazePart.ROOF;
+	private boolean getSpawnAction(String value) {
+		if ("spawn".equals(value)) {
+			return true;
+		} else if ("despawn".equals(value)) {
+			return false;
 		}
-		return MazePart.WALLS;
+		throw new IllegalArgumentException(EXCEPTION_TEXT
+				.replace("%type%", "Action")
+				.replace("%value%", String.join("/", getArgs().get(0).getTabList())));
 	}
 
 	/**
 	 * Converts a list of material strings in the format "count(optional)*material:subId(optional)" into a BlockPalette.
+	 *
 	 * @param stringArgs the list of strings provided by the command sender
 	 * @return the BlockPalette created from the strings
 	 * @throws TextException if the strings are not in the correct format
 	 */
-	public BlockPalette deserializeBlockPalette(List<ArgValue> stringArgs) throws TextException {
-		BlockPalette palette = new BlockPalette();
-		
+	public Map<String, Integer> deserializeLootChestPrefabs(List<ArgValue> stringArgs) throws TextException {
+		Map<String, Integer> chestAmounts = new HashMap<>();
+
 		for (ArgValue input : stringArgs) {
 			String inputString = input.get();
 			int count = 1;
-			String materialString;
-			
+			String chestName;
+
 			if (inputString.contains("*")) {
 				String[] stringParts = inputString.split("\\*");
-				
+
 				if (stringParts.length < 1 || !MathUtil.isInt(stringParts[0])) {
 					throw new IllegalArgumentException("invalid input: " + inputString);
 				}
 				count = Integer.parseInt(stringParts[0]);
-				materialString = stringParts[1];
+				chestName = stringParts[1];
 			} else {
-				materialString = inputString;
+				chestName = inputString;
 			}
-			try {
-				BlockType blockType = BlockType.get(materialString, true);
-				palette.addBlock(blockType, MathUtil.clamp(count, 1, 1000));
-			} catch (IllegalArgumentException e) {
-				throw new TextException(Message.ERROR_INVALID_BLOCK_NAME, new Placeholder("block", materialString));
+			if (!lootHandler.chestExists(chestName)) {
+				//TODO add lang message
+				throw new TextException(Message.ERROR_INVALID_BLOCK_NAME, new Placeholder("block", chestName + " (chest)"));
 			}
+			Bukkit.broadcastMessage("spawn " + count + " * " + chestName);
+			chestAmounts.put(chestName, count);
 		}
-		return palette;
+		return chestAmounts;
 	}
-	
+
 	/**
 	 * Returns a list of block names that the sender could tab complete to.
 	 */
 	@Override
 	public List<String> getTabList(String[] stringArgs) {
 		List<String> tabList = super.getTabList(stringArgs);
-		
+
 		if (!tabList.isEmpty()) {
 			return tabList;
 		}
 		String tabbedArg = stringArgs[stringArgs.length - 1];
 		String factorString;
-		
+
 		if (tabbedArg.contains("*")) {
 			String[] stringParts = tabbedArg.split("\\*");
-			
+
 			if (stringParts.length < 1 || stringParts.length > 2 || !MathUtil.isInt(stringParts[0])) {
 				return tabList;
 			}
 			factorString = stringParts[0] + "*";
-			
+
 		} else if (MathUtil.isInt(tabbedArg)) {
 			factorString = tabbedArg + "*";
 		} else {
 			return MaterialUtil.getBlockNames();
 		}
-		
+
 		for (String blockName : MaterialUtil.getBlockNames()) {
 			tabList.add(factorString + blockName);
 		}

--- a/src/main/java/me/gorgeousone/tangledmaze/command/UnbuildMazeCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/command/UnbuildMazeCommand.java
@@ -42,6 +42,10 @@ public class UnbuildMazeCommand extends ArgCommand {
 			Message.ERROR_MAZE_MISSING.sendTo(sender);
 			return;
 		}
+		if (!sessionHandler.isBuilt(maze)) {
+			Message.INFO_MAZE_NOT_BUILT.sendTo(sender);
+			return;
+		}
 		MazePart mazePart = MazePart.WALLS;
 		
 		if (usedFlags.contains("floor")) {

--- a/src/main/java/me/gorgeousone/tangledmaze/data/Message.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/data/Message.java
@@ -118,7 +118,7 @@ public class Message {
 		ERROR_INVALID_BLOCK_PROPERTY = createError("invalid-block-property", errors);
 	}
 
-	public static Text createHelpText(String header, ConfigurationSection section, String path) {
+	private static Text createHelpText(String header, ConfigurationSection section, String path) {
 		return new Text(ChatColor.DARK_GREEN + header + "\\n" + ChatColor.GREEN + section.get(path));
 	}
 
@@ -126,7 +126,7 @@ public class Message {
 		return new Text(Constants.prefix + section.getString(path));
 	}
 
-	public static Text createError(String path, ConfigurationSection section) {
+	private static Text createError(String path, ConfigurationSection section) {
 		return new Text(ChatColor.RED + section.getString(path));
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/event/MazeUnbuildEvent.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/event/MazeUnbuildEvent.java
@@ -1,6 +1,7 @@
 package me.gorgeousone.tangledmaze.event;
 
 import me.gorgeousone.tangledmaze.clip.Clip;
+import me.gorgeousone.tangledmaze.maze.MazePart;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
@@ -10,15 +11,21 @@ public class MazeUnbuildEvent extends Event {
 	
 	private static final HandlerList HANDLERS = new HandlerList();
 	private final Clip maze;
+	private final MazePart mazePart;
 	
-	public MazeUnbuildEvent(Clip maze) {
+	public MazeUnbuildEvent(Clip maze, MazePart mazePart) {
 		this.maze = maze;
+		this.mazePart = mazePart;
 	}
 	
 	public Clip getMaze() {
 		return maze;
 	}
-	
+
+	public MazePart getMazePart() {
+		return mazePart;
+	}
+
 	public UUID getOwnerId() {
 		return maze.getOwnerId();
 	}

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/GridCell.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/GridCell.java
@@ -111,6 +111,20 @@ public class GridCell {
 		}
 		return facings;
 	}
+
+	public Set<Vec2> getWalls(Direction direction) {
+		Vec2 iter = direction.isPositive() ? min.clone() : max.clone().add(-1, -1);
+		Vec2 step = direction.getVec2();
+		Vec2 cellSize = max.clone().sub(min);
+		int limit = direction.isCollinearX() ? cellSize.getX() : cellSize.getZ();
+		Set<Vec2> walls = new HashSet<>();
+
+		for (int i = 0; i < limit; ++i) {
+			walls.add(iter.clone());
+			iter.add(step);
+		}
+		return walls;
+	}
 	
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/building/BuildHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/building/BuildHandler.java
@@ -40,8 +40,7 @@ public class BuildHandler {
 		if (mazePart != MazePart.WALLS && !sessionHandler.isBuilt(maze)) {
 			throw new TextException(Message.INFO_MAZE_NOT_BUILT);
 		}
-		sessionHandler.backupMaze(maze, settings);
-		MazeBackup backup = sessionHandler.getBackup(maze);
+		MazeBackup backup = sessionHandler.backupMaze(maze, settings);
 		backup.createMazeMapIfAbsent(settings);
 		MazeMap mazeMap = backup.getMazeMap();
 		

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/building/BuildHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/building/BuildHandler.java
@@ -89,7 +89,7 @@ public class BuildHandler {
 				backup.removeAllMazeParts();
 				backup.getMaze().updateHeights();
 				backup.getMaze().setEditable(true);
-				Bukkit.getPluginManager().callEvent(new MazeUnbuildEvent(maze));
+				Bukkit.getPluginManager().callEvent(new MazeUnbuildEvent(maze, mazePart));
 				callback.run();
 			}).runTaskTimer(plugin, 0, 1);
 			return;
@@ -100,7 +100,7 @@ public class BuildHandler {
 		}
 		new BlockResetter(plugin, backup.getBlocks(mazePart), ConfigSettings.BLOCKS_PLACED_PER_TICK, () -> {
 			backup.removeMazePart(mazePart);
-			Bukkit.getPluginManager().callEvent(new MazeUnbuildEvent(maze));
+			Bukkit.getPluginManager().callEvent(new MazeUnbuildEvent(maze, mazePart));
 			callback.run();
 		}).runTaskTimer(plugin, 0, 1);
 	}

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
@@ -4,6 +4,7 @@ import me.gorgeousone.tangledmaze.generation.GridCell;
 import me.gorgeousone.tangledmaze.generation.GridMap;
 import me.gorgeousone.tangledmaze.util.Direction;
 import me.gorgeousone.tangledmaze.util.Vec2;
+import org.bukkit.block.BlockFace;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -27,13 +28,13 @@ public class Room {
 	}
 
 	private void listCells() {
-		for (int x = gridMin.getX(); x < gridMax.getX(); x += 2) {
-			for (int z = gridMin.getZ(); z < gridMax.getZ(); z += 2) {
+		for (int x = gridMin.getX(); x < gridMax.getX(); ++x) {
+			for (int z = gridMin.getZ(); z < gridMax.getZ(); ++x) {
 				Vec2 gridPos = new Vec2(x, z);
 				pathCells.add(gridPos);
 
 				if (x == gridMin.getX() || x == gridMax.getX() - 1 ||
-					z == gridMin.getZ() || z == gridMax.getZ()- 1) {
+					z == gridMin.getZ() || z == gridMax.getZ() - 1) {
 					borderCells.add(gridPos);
 				}
 			}
@@ -41,7 +42,11 @@ public class Room {
 	}
 
 	public Set<Vec2> getPathCells() {
-		return pathCells;
+		return new HashSet<>(pathCells);
+	}
+
+	public Set<Vec2> getBorderCells() {
+		return new HashSet<>(borderCells);
 	}
 
 	public Vec2 getGridMin() {
@@ -57,6 +62,19 @@ public class Room {
 		       gridPos.getZ() >= gridMin.getZ() &&
 		       gridPos.getX() < gridMax.getX() &&
 		       gridPos.getZ() < gridMax.getZ();
+	}
+
+	public Direction getWallFacing(Vec2 gridPos) {
+		if (gridPos.getZ() == gridMin.getZ()) {
+			return Direction.NORTH;
+		} else if (gridPos.getZ() == gridMax.getZ() - 1) {
+			return Direction.SOUTH;
+		} else if (gridPos.getX() == gridMin.getX()) {
+			return Direction.WEST;
+		} else if (gridPos.getX() == gridMax.getX() - 1) {
+			return Direction.EAST;
+		}
+		return null;
 	}
 
 	public void floodFillRoom(GridCell startCell, GridMap gridMap) {

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
@@ -29,7 +29,7 @@ public class Room {
 
 	private void listCells() {
 		for (int x = gridMin.getX(); x < gridMax.getX(); ++x) {
-			for (int z = gridMin.getZ(); z < gridMax.getZ(); ++x) {
+			for (int z = gridMin.getZ(); z < gridMax.getZ(); ++z) {
 				Vec2 gridPos = new Vec2(x, z);
 				pathCells.add(gridPos);
 

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootChangeEvent.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootChangeEvent.java
@@ -1,0 +1,34 @@
+package me.gorgeousone.tangledmaze.loot;
+
+import me.gorgeousone.tangledmaze.clip.Clip;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+public class LootChangeEvent extends Event {
+
+	private static final HandlerList HANDLERS = new HandlerList();
+	private final Clip maze;
+
+	public LootChangeEvent(Clip maze) {
+		this.maze = maze;
+	}
+	
+	public Clip getMaze() {
+		return maze;
+	}
+	
+	public UUID getOwnerId() {
+		return maze.getOwnerId();
+	}
+	
+	@Override
+	public HandlerList getHandlers() {
+		return HANDLERS;
+	}
+	
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+}

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootChestLocator.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootChestLocator.java
@@ -1,0 +1,50 @@
+package me.gorgeousone.tangledmaze.loot;
+
+import me.gorgeousone.tangledmaze.generation.GridCell;
+import me.gorgeousone.tangledmaze.generation.GridMap;
+import me.gorgeousone.tangledmaze.generation.MazeMap;
+import me.gorgeousone.tangledmaze.generation.paving.Room;
+import me.gorgeousone.tangledmaze.util.BlockVec;
+import me.gorgeousone.tangledmaze.util.Direction;
+import me.gorgeousone.tangledmaze.util.Vec2;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LootChestLocator {
+
+	/**
+	 * @return map of non-junction grid cells in all rooms mapped to facing direction
+	 */
+	public static Map<Vec2, Direction> findRoomWallCells(MazeMap mazeMap) {
+		GridMap gridMap = mazeMap.getPathMap();
+		List<Room> rooms = gridMap.getRooms();
+		Map<Vec2, Direction> blocks = new HashMap<>();
+
+		for (Room room : rooms) {
+			for (Vec2 gridPos : room.getBorderCells()) {
+				if (isJunction(gridPos)) {
+					continue;
+				}
+				GridCell cell = gridMap.getCell(gridPos);
+				Direction facing = room.getWallFacing(gridPos);
+				blocks.putAll(getWallPositions(cell, facing.getOpposite(), mazeMap));
+			}
+		}
+		return blocks;
+	}
+
+	private static boolean isJunction(Vec2 gridPos) {
+		return gridPos.getX() % 2 == 0 && gridPos.getZ() % 2 == 0;
+	}
+
+	private static Map<Vec2, Direction> getWallPositions(GridCell cell, Direction direction, MazeMap mazeMap) {
+		Map<Vec2, Direction> wallBlocks = new HashMap<>();
+
+		for (Vec2 pos : cell.getWalls(direction)) {
+			wallBlocks.put(pos, direction);
+		}
+		return wallBlocks;
+	}
+}

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
@@ -86,14 +86,14 @@ public class LootHandler {
 
 	private void spawnLootChest(String chestPrefabName, Location location, BlockFace facing) {
 		Bukkit.broadcastMessage("spawn " + chestPrefabName + " at " + location.toVector());
+
 		if (!chestExists(chestPrefabName)) {
 			throw new IllegalArgumentException("Could not find loot chest \"" + chestPrefabName + "\".");
 		}
 		Block chestBlock = placeChestBlock(location, facing);
 		String chestName = String.format("zz-%s-%s", chestPrefabName, UUID.randomUUID());
-		Lootchest chest = registerLootChest(chestName, chestBlock);
 		Lootchest prefab = lootChestPlugin.getLootChest().get(chestPrefabName);
-		lootChestPlugin.getUtils().copychest(chest, prefab);
+		createChestFromPrefab(chestName, chestBlock, prefab);
 	}
 
 	private Block placeChestBlock(Location location, BlockFace facing) {
@@ -105,11 +105,10 @@ public class LootHandler {
 		return location.getBlock();
 	}
 
-	private Lootchest registerLootChest(String name, Block chest) {
-		Lootchest loot = new Lootchest(chest, name);
-		lootChestPlugin.getLootChest().put(name, loot);
-		lootChestPlugin.getLootChest().get(name).spawn(true);
-		lootChestPlugin.getUtils().updateData(Main.getInstance().getLootChest().get(name));
-		return loot;
+	private Lootchest createChestFromPrefab(String name, Block chestBlock, Lootchest prefab) {
+		Lootchest newChest = new Lootchest(chestBlock, name);
+		lootChestPlugin.getLootChest().put(name, newChest);
+		lootChestPlugin.getUtils().copychest(prefab, newChest);
+		return newChest;
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
@@ -1,0 +1,57 @@
+package me.gorgeousone.tangledmaze.loot;
+
+import fr.black_eyes.lootchest.Lootchest;
+import fr.black_eyes.lootchest.Main;
+import me.gorgeousone.tangledmaze.util.blocktype.BlockLocType;
+import me.gorgeousone.tangledmaze.util.blocktype.BlockType;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class LootHandler {
+
+	private final Map<BlockFace, Integer> legacyDirIds;
+	private final Main lootChestPlugin;
+
+	public LootHandler(Main lootChestPlugin) {
+		this.lootChestPlugin = lootChestPlugin;
+		this.legacyDirIds = new HashMap<>();
+
+		legacyDirIds.put(BlockFace.NORTH, 2);
+		legacyDirIds.put(BlockFace.SOUTH, 3);
+		legacyDirIds.put(BlockFace.WEST, 4);
+		legacyDirIds.put(BlockFace.EAST, 5);
+	}
+
+	public void spawnLootChest(String chestPrefabName, Location location, BlockFace facing) {
+		if (!lootChestPlugin.getLootChest().containsKey(chestPrefabName)) {
+			throw new IllegalArgumentException("Could not find loot chest \"" + chestPrefabName + "\".");
+		}
+		Block chestBlock = placeChestBlock(location, facing);
+		String chestName = UUID.randomUUID().toString();
+		Lootchest chest = registerLootChest(chestName, chestBlock);
+		Lootchest prefab = lootChestPlugin.getLootChest().get(chestPrefabName);
+		lootChestPlugin.getUtils().copychest(chest, prefab);
+	}
+
+	private Block placeChestBlock(Location location, BlockFace facing) {
+		BlockType blockType = BlockType.get(
+				String.format("CHEST[facing=%s]", facing.name()),
+				"CHEST:" + legacyDirIds.get(facing));
+		BlockLocType chestBlock = new BlockLocType(location, blockType);
+		chestBlock.updateBlock(false);
+		return location.getBlock();
+	}
+	private Lootchest registerLootChest(String name, Block chest) {
+		Lootchest loot = new Lootchest(chest, name);
+		lootChestPlugin.getLootChest().put(name, loot);
+		lootChestPlugin.getLootChest().get(name).spawn(true);
+		lootChestPlugin.getUtils().updateData(Main.getInstance().getLootChest().get(name));
+		return loot;
+	}
+}

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
@@ -2,14 +2,27 @@ package me.gorgeousone.tangledmaze.loot;
 
 import fr.black_eyes.lootchest.Lootchest;
 import fr.black_eyes.lootchest.Main;
+import me.gorgeousone.tangledmaze.data.Message;
+import me.gorgeousone.tangledmaze.generation.GridCell;
+import me.gorgeousone.tangledmaze.generation.GridMap;
+import me.gorgeousone.tangledmaze.generation.MazeMap;
+import me.gorgeousone.tangledmaze.generation.paving.Room;
+import me.gorgeousone.tangledmaze.util.BlockVec;
+import me.gorgeousone.tangledmaze.util.Direction;
+import me.gorgeousone.tangledmaze.util.Vec2;
 import me.gorgeousone.tangledmaze.util.blocktype.BlockLocType;
 import me.gorgeousone.tangledmaze.util.blocktype.BlockType;
+import me.gorgeousone.tangledmaze.util.text.Placeholder;
+import me.gorgeousone.tangledmaze.util.text.TextException;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -28,7 +41,67 @@ public class LootHandler {
 		legacyDirIds.put(BlockFace.EAST, 5);
 	}
 
-	public void spawnLootChest(String chestPrefabName, Location location, BlockFace facing) {
+	public Map<BlockVec, String> placeChests(MazeMap mazeMap, Map<String, Integer> chestAmounts) throws TextException {
+		for (String chestName : chestAmounts.keySet()) {
+			if (!lootChestPlugin.getLootChest().containsKey(chestName)) {
+				//TODO list error in lang
+				throw new TextException(Message.ERROR_INVALID_SETTING, new Placeholder("setting", "Chest does not exits" + chestName));
+			}
+		}
+		List<String> chestList = new ArrayList<>();
+
+		for (Map.Entry<String, Integer> entry : chestAmounts.entrySet()) {
+			String item = entry.getKey();
+			int amount = entry.getValue();
+			for (int i = 0; i < amount; i++) {
+				chestList.add(item);
+			}
+		}
+		Collections.shuffle(chestList);
+		Map<GridCell, BlockFace> wallCells = findRoomWallCells(mazeMap);
+		int spawnAttempts = 1000;
+
+		for (String item : chestList) {
+
+		}
+		return null;
+	}
+
+	/**
+	 * @return map of non-junction grid cells in all rooms mapped to facing direction
+	 */
+	private Map<BlockVec, Direction> findRoomWallCells(MazeMap mazeMap) {
+		GridMap gridMap = mazeMap.getPathMap();
+		List<Room> rooms = gridMap.getRooms();
+		Map<BlockVec, Direction> blocks = new HashMap<>();
+
+		for (Room room : rooms) {
+			for (Vec2 gridPos : room.getBorderCells()) {
+				if (isJunction(gridPos)) {
+					continue;
+				}
+				GridCell cell = gridMap.getCell(gridPos);
+				Direction facing = room.getWallFacing(gridPos);
+				blocks.putAll(getWallBlocks(cell, facing, mazeMap));
+			}
+		}
+		return blocks;
+	}
+
+	private boolean isJunction(Vec2 gridPos) {
+		return gridPos.getX() % 2 == 0 && gridPos.getZ() % 2 == 0;
+	}
+
+	private Map<BlockVec, Direction> getWallBlocks(GridCell cell, Direction direction, MazeMap mazeMap) {
+		Map<BlockVec, Direction> wallBlocks = new HashMap<>();
+
+		for (Vec2 pos : cell.getWalls(direction)) {
+			wallBlocks.put(new BlockVec(pos, mazeMap.getY(pos) + 1), direction);
+		}
+		return wallBlocks;
+	}
+
+	private void spawnLootChest(String chestPrefabName, Location location, BlockFace facing) {
 		if (!lootChestPlugin.getLootChest().containsKey(chestPrefabName)) {
 			throw new IllegalArgumentException("Could not find loot chest \"" + chestPrefabName + "\".");
 		}

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
@@ -2,22 +2,18 @@ package me.gorgeousone.tangledmaze.loot;
 
 import fr.black_eyes.lootchest.Lootchest;
 import fr.black_eyes.lootchest.Main;
-import me.gorgeousone.tangledmaze.data.Message;
-import me.gorgeousone.tangledmaze.generation.GridCell;
-import me.gorgeousone.tangledmaze.generation.GridMap;
+import me.gorgeousone.tangledmaze.SessionHandler;
 import me.gorgeousone.tangledmaze.generation.MazeMap;
-import me.gorgeousone.tangledmaze.generation.paving.Room;
 import me.gorgeousone.tangledmaze.util.BlockVec;
 import me.gorgeousone.tangledmaze.util.Direction;
 import me.gorgeousone.tangledmaze.util.Vec2;
 import me.gorgeousone.tangledmaze.util.blocktype.BlockLocType;
 import me.gorgeousone.tangledmaze.util.blocktype.BlockType;
-import me.gorgeousone.tangledmaze.util.text.Placeholder;
 import me.gorgeousone.tangledmaze.util.text.TextException;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,10 +24,12 @@ import java.util.UUID;
 
 public class LootHandler {
 
-	private final Map<BlockFace, Integer> legacyDirIds;
+	private final SessionHandler sessionHandler;
 	private final Main lootChestPlugin;
+	private final Map<BlockFace, Integer> legacyDirIds;
 
-	public LootHandler(Main lootChestPlugin) {
+	public LootHandler(SessionHandler sessionHandler, Main lootChestPlugin) {
+		this.sessionHandler = sessionHandler;
 		this.lootChestPlugin = lootChestPlugin;
 		this.legacyDirIds = new HashMap<>();
 
@@ -41,13 +39,32 @@ public class LootHandler {
 		legacyDirIds.put(BlockFace.EAST, 5);
 	}
 
+	public boolean chestExists(String chestName) {
+		return lootChestPlugin.getLootChest().containsKey(chestName);
+	}
+
 	public Map<BlockVec, String> placeChests(MazeMap mazeMap, Map<String, Integer> chestAmounts) throws TextException {
-		for (String chestName : chestAmounts.keySet()) {
-			if (!lootChestPlugin.getLootChest().containsKey(chestName)) {
-				//TODO list error in lang
-				throw new TextException(Message.ERROR_INVALID_SETTING, new Placeholder("setting", "Chest does not exits" + chestName));
-			}
+		List<String> chestList = listChests(chestAmounts);
+		Map<Vec2, Direction> wallDirs = LootChestLocator.findRoomWallCells(mazeMap);
+		List<Vec2> walls = new ArrayList<>(wallDirs.keySet());
+
+		Collections.shuffle(chestList);
+		Collections.shuffle(walls);
+
+		while (!chestList.isEmpty() && !walls.isEmpty()) {
+			String name = chestList.remove(0);
+			Vec2 wall = walls.remove(0);
+
+			Direction dir = wallDirs.get(wall);
+			removeNeighbors(walls, wall);
+			spawnLootChest(name, wall.toLocation(mazeMap.getWorld(), mazeMap.getY(wall) + 1), dir.getFace());
+
 		}
+		Bukkit.broadcastMessage("done");
+		return null;
+	}
+
+	private List<String> listChests(Map<String, Integer> chestAmounts) {
 		List<String> chestList = new ArrayList<>();
 
 		for (Map.Entry<String, Integer> entry : chestAmounts.entrySet()) {
@@ -58,55 +75,22 @@ public class LootHandler {
 			}
 		}
 		Collections.shuffle(chestList);
-		Map<GridCell, BlockFace> wallCells = findRoomWallCells(mazeMap);
-		int spawnAttempts = 1000;
-
-		for (String item : chestList) {
-
-		}
-		return null;
+		return chestList;
 	}
 
-	/**
-	 * @return map of non-junction grid cells in all rooms mapped to facing direction
-	 */
-	private Map<BlockVec, Direction> findRoomWallCells(MazeMap mazeMap) {
-		GridMap gridMap = mazeMap.getPathMap();
-		List<Room> rooms = gridMap.getRooms();
-		Map<BlockVec, Direction> blocks = new HashMap<>();
-
-		for (Room room : rooms) {
-			for (Vec2 gridPos : room.getBorderCells()) {
-				if (isJunction(gridPos)) {
-					continue;
-				}
-				GridCell cell = gridMap.getCell(gridPos);
-				Direction facing = room.getWallFacing(gridPos);
-				blocks.putAll(getWallBlocks(cell, facing, mazeMap));
-			}
+	private void removeNeighbors(List<Vec2> positions, Vec2 pos) {
+		for (Direction dir : Direction.CARDINALS) {
+			positions.remove(pos.clone().add(dir.getVec2()));
 		}
-		return blocks;
-	}
-
-	private boolean isJunction(Vec2 gridPos) {
-		return gridPos.getX() % 2 == 0 && gridPos.getZ() % 2 == 0;
-	}
-
-	private Map<BlockVec, Direction> getWallBlocks(GridCell cell, Direction direction, MazeMap mazeMap) {
-		Map<BlockVec, Direction> wallBlocks = new HashMap<>();
-
-		for (Vec2 pos : cell.getWalls(direction)) {
-			wallBlocks.put(new BlockVec(pos, mazeMap.getY(pos) + 1), direction);
-		}
-		return wallBlocks;
 	}
 
 	private void spawnLootChest(String chestPrefabName, Location location, BlockFace facing) {
-		if (!lootChestPlugin.getLootChest().containsKey(chestPrefabName)) {
+		Bukkit.broadcastMessage("spawn " + chestPrefabName + " at " + location.toVector());
+		if (!chestExists(chestPrefabName)) {
 			throw new IllegalArgumentException("Could not find loot chest \"" + chestPrefabName + "\".");
 		}
 		Block chestBlock = placeChestBlock(location, facing);
-		String chestName = UUID.randomUUID().toString();
+		String chestName = String.format("zz-%s-%s", chestPrefabName, UUID.randomUUID());
 		Lootchest chest = registerLootChest(chestName, chestBlock);
 		Lootchest prefab = lootChestPlugin.getLootChest().get(chestPrefabName);
 		lootChestPlugin.getUtils().copychest(chest, prefab);
@@ -120,6 +104,7 @@ public class LootHandler {
 		chestBlock.updateBlock(false);
 		return location.getBlock();
 	}
+
 	private Lootchest registerLootChest(String name, Block chest) {
 		Lootchest loot = new Lootchest(chest, name);
 		lootChestPlugin.getLootChest().put(name, loot);

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootRemoveCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootRemoveCommand.java
@@ -6,6 +6,7 @@ import me.gorgeousone.tangledmaze.cmdframework.command.BaseCommand;
 import me.gorgeousone.tangledmaze.data.Message;
 import me.gorgeousone.tangledmaze.maze.MazeBackup;
 import me.gorgeousone.tangledmaze.util.text.Placeholder;
+import me.gorgeousone.tangledmaze.util.text.TextException;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 
@@ -37,14 +38,7 @@ public class LootRemoveCommand extends BaseCommand {
 			Message.ERROR_MAZE_MISSING.sendTo(sender);
 			return;
 		}
-		if (!sessionHandler.isBuilt(maze)) {
-			Message.INFO_MAZE_NOT_BUILT.sendTo(sender);
-			return;
-		}
-		MazeBackup backup = sessionHandler.getBackup(maze);
-		lootHandler.removeChests(backup.getLootLocations().keySet());
-		sender.sendMessage("removed " + backup.getLootLocations().size() + " chests");
-		backup.clearLootLocations();
-		Bukkit.getPluginManager().callEvent(new LootChangeEvent(maze));
+		int removedChestCount = lootHandler.removeChests(maze);
+		sender.sendMessage("remove " + removedChestCount + " chests");
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootRemoveCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootRemoveCommand.java
@@ -1,0 +1,47 @@
+package me.gorgeousone.tangledmaze.loot;
+
+import me.gorgeousone.tangledmaze.SessionHandler;
+import me.gorgeousone.tangledmaze.clip.Clip;
+import me.gorgeousone.tangledmaze.cmdframework.command.BaseCommand;
+import me.gorgeousone.tangledmaze.data.Message;
+import me.gorgeousone.tangledmaze.maze.MazeBackup;
+import me.gorgeousone.tangledmaze.util.text.Placeholder;
+import org.bukkit.command.CommandSender;
+
+import java.util.UUID;
+
+public class LootRemoveCommand extends BaseCommand {
+
+	private final SessionHandler sessionHandler;
+	private final LootHandler lootHandler;
+	private final boolean isAvailable;
+
+	public LootRemoveCommand(SessionHandler sessionHandler, LootHandler lootHandler, boolean isAvailable) {
+		super("loot");
+		this.sessionHandler = sessionHandler;
+		this.lootHandler = lootHandler;
+		this.isAvailable = isAvailable;
+	}
+
+	@Override
+	protected void onCommand(CommandSender sender, String[] args) {
+		if (!isAvailable) {
+			Message.ERROR_INVALID_SETTING.sendTo(sender, new Placeholder("setting", "LootChest plugin not loaded"));
+			return;
+		}
+		UUID playerId = getSenderId(sender);
+		Clip maze = sessionHandler.getMazeClip(playerId);
+
+		if (null == maze) {
+			Message.ERROR_MAZE_MISSING.sendTo(sender);
+			return;
+		}
+		if (!sessionHandler.isBuilt(maze)) {
+			Message.INFO_MAZE_NOT_BUILT.sendTo(sender);
+			return;
+		}
+		MazeBackup backup = sessionHandler.getBackup(maze);
+		lootHandler.removeChests(backup.getLootLocations().keySet());
+		backup.removeLoot();
+	}
+}

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootRemoveCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootRemoveCommand.java
@@ -6,6 +6,7 @@ import me.gorgeousone.tangledmaze.cmdframework.command.BaseCommand;
 import me.gorgeousone.tangledmaze.data.Message;
 import me.gorgeousone.tangledmaze.maze.MazeBackup;
 import me.gorgeousone.tangledmaze.util.text.Placeholder;
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 
 import java.util.UUID;
@@ -17,7 +18,7 @@ public class LootRemoveCommand extends BaseCommand {
 	private final boolean isAvailable;
 
 	public LootRemoveCommand(SessionHandler sessionHandler, LootHandler lootHandler, boolean isAvailable) {
-		super("loot");
+		super("remove");
 		this.sessionHandler = sessionHandler;
 		this.lootHandler = lootHandler;
 		this.isAvailable = isAvailable;
@@ -42,6 +43,8 @@ public class LootRemoveCommand extends BaseCommand {
 		}
 		MazeBackup backup = sessionHandler.getBackup(maze);
 		lootHandler.removeChests(backup.getLootLocations().keySet());
-		backup.removeLoot();
+		sender.sendMessage("removed " + backup.getLootLocations().size() + " chests");
+		backup.clearLootLocations();
+		Bukkit.getPluginManager().callEvent(new LootChangeEvent(maze));
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootRespawnCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootRespawnCommand.java
@@ -1,0 +1,46 @@
+package me.gorgeousone.tangledmaze.loot;
+
+import me.gorgeousone.tangledmaze.SessionHandler;
+import me.gorgeousone.tangledmaze.clip.Clip;
+import me.gorgeousone.tangledmaze.cmdframework.command.BaseCommand;
+import me.gorgeousone.tangledmaze.data.Message;
+import me.gorgeousone.tangledmaze.maze.MazeBackup;
+import me.gorgeousone.tangledmaze.util.text.Placeholder;
+import org.bukkit.command.CommandSender;
+
+import java.util.UUID;
+
+public class LootRespawnCommand extends BaseCommand {
+
+	private final SessionHandler sessionHandler;
+	private final LootHandler lootHandler;
+	private final boolean isAvailable;
+
+	public LootRespawnCommand(SessionHandler sessionHandler, LootHandler lootHandler, boolean isAvailable) {
+		super("loot");
+		this.sessionHandler = sessionHandler;
+		this.lootHandler = lootHandler;
+		this.isAvailable = isAvailable;
+	}
+
+	@Override
+	protected void onCommand(CommandSender sender, String[] args) {
+		if (!isAvailable) {
+			Message.ERROR_INVALID_SETTING.sendTo(sender, new Placeholder("setting", "LootChest plugin not loaded"));
+			return;
+		}
+		UUID playerId = getSenderId(sender);
+		Clip maze = sessionHandler.getMazeClip(playerId);
+
+		if (null == maze) {
+			Message.ERROR_MAZE_MISSING.sendTo(sender);
+			return;
+		}
+		if (!sessionHandler.isBuilt(maze)) {
+			Message.INFO_MAZE_NOT_BUILT.sendTo(sender);
+			return;
+		}
+		MazeBackup backup = sessionHandler.getBackup(maze);
+		lootHandler.respawnChests(backup.getLootLocations().keySet());
+	}
+}

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootRespawnCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootRespawnCommand.java
@@ -17,7 +17,7 @@ public class LootRespawnCommand extends BaseCommand {
 	private final boolean isAvailable;
 
 	public LootRespawnCommand(SessionHandler sessionHandler, LootHandler lootHandler, boolean isAvailable) {
-		super("loot");
+		super("respawn");
 		this.sessionHandler = sessionHandler;
 		this.lootHandler = lootHandler;
 		this.isAvailable = isAvailable;

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
@@ -53,24 +53,17 @@ public class LootSpawnCommand extends ArgCommand {
 			Message.ERROR_MAZE_MISSING.sendTo(sender);
 			return;
 		}
-		if (!sessionHandler.isBuilt(maze)) {
-			Message.INFO_MAZE_NOT_BUILT.sendTo(sender);
-			return;
-		}
-		MazeBackup backup = sessionHandler.getBackup(maze);
 		Map<String, Integer> chestAmounts;
 		Map<String, BlockVec> addedChests;
 
 		try {
 			chestAmounts = deserializeLootChestPrefabs(argValues);
-			addedChests = lootHandler.spawnChests(backup.getMazeMap(), chestAmounts, backup.getLootLocations().values());
+			addedChests = lootHandler.spawnChests(maze, chestAmounts);
 		} catch (TextException e) {
 			e.sendTextTo(sender);
 			return;
 		}
-		backup.addLootLocations(addedChests);
-		sender.sendMessage("Placed total " + backup.getLootLocations().size() + " chests");
-		Bukkit.getPluginManager().callEvent(new LootChangeEvent(maze));
+		sender.sendMessage("Placed " + addedChests.size() + " chests");
 	}
 
 	/**

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
@@ -1,159 +1,139 @@
-package me.gorgeousone.tangledmaze.command;
+package me.gorgeousone.tangledmaze.loot;
 
 import me.gorgeousone.tangledmaze.SessionHandler;
 import me.gorgeousone.tangledmaze.clip.Clip;
+import me.gorgeousone.tangledmaze.cmdframework.argument.ArgType;
 import me.gorgeousone.tangledmaze.cmdframework.argument.ArgValue;
+import me.gorgeousone.tangledmaze.cmdframework.argument.Argument;
 import me.gorgeousone.tangledmaze.cmdframework.command.ArgCommand;
 import me.gorgeousone.tangledmaze.data.Message;
-import me.gorgeousone.tangledmaze.generation.MazeMap;
-import me.gorgeousone.tangledmaze.generation.building.BlockPalette;
-import me.gorgeousone.tangledmaze.generation.building.BuildHandler;
-import me.gorgeousone.tangledmaze.loot.LootHandler;
-import me.gorgeousone.tangledmaze.maze.MazePart;
-import me.gorgeousone.tangledmaze.maze.MazeSettings;
-import me.gorgeousone.tangledmaze.tool.ToolHandler;
+import me.gorgeousone.tangledmaze.maze.MazeBackup;
+import me.gorgeousone.tangledmaze.util.BlockVec;
 import me.gorgeousone.tangledmaze.util.MaterialUtil;
 import me.gorgeousone.tangledmaze.util.MathUtil;
-import me.gorgeousone.tangledmaze.util.blocktype.BlockType;
 import me.gorgeousone.tangledmaze.util.text.Placeholder;
 import me.gorgeousone.tangledmaze.util.text.TextException;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-/**
- * The command to build the walls, floor or roof of a maze.
- */
-public class BuildMazeCommand extends ArgCommand {
-	
+public class LootSpawnCommand extends ArgCommand {
+
+	private static final String EXCEPTION_TEXT = ChatColor.RED + "'%type%' is can only be %value%.";
+
 	private final SessionHandler sessionHandler;
-	private final BuildHandler buildHandler;
-	private final ToolHandler toolHandler;
+	private final LootHandler lootHandler;
+	private final boolean isAvailable;
 
-	public BuildMazeCommand(SessionHandler sessionHandler, BuildHandler buildHandler, ToolHandler toolHandler) {
-		super("build");
-		addAlias("b");
-		addFlag("floor");
-		addFlag("roof");
-		addFlag("hollow");
+	public LootSpawnCommand(SessionHandler sessionHandler, LootHandler lootHandler, boolean isAvailable) {
+		super("loot");
+		addArg(new Argument("x*chest...", ArgType.STRING));
 
-		this.toolHandler = toolHandler;
 		this.sessionHandler = sessionHandler;
-		this.buildHandler = buildHandler;
+		this.lootHandler = lootHandler;
+		this.isAvailable = isAvailable;
 	}
 
 	@Override
 	protected void executeArgs(CommandSender sender, List<ArgValue> argValues, Set<String> usedFlags) {
+		if (!isAvailable) {
+			Message.ERROR_INVALID_SETTING.sendTo(sender, new Placeholder("setting", "LootChest plugin not loaded"));
+			return;
+		}
 		UUID playerId = getSenderId(sender);
 		Clip maze = sessionHandler.getMazeClip(playerId);
-		
+
 		if (null == maze) {
 			Message.ERROR_MAZE_MISSING.sendTo(sender);
 			return;
 		}
-		if (maze.getExits().isEmpty()) {
-			Message.ERROR_EXIT_MISSING.sendTo(sender);
+		if (!sessionHandler.isBuilt(maze)) {
+			Message.INFO_MAZE_NOT_BUILT.sendTo(sender);
 			return;
 		}
-		MazeSettings settings = sessionHandler.getSettings(playerId);
-		MazePart mazePart = getMazePart(usedFlags);
-
-		if (!argValues.isEmpty()) {
-			try {
-				BlockPalette palette = deserializeBlockPalette(argValues);
-				settings.setPalette(mazePart, palette);
-			} catch (TextException e) {
-				e.sendTextTo(sender);
-				return;
-			}
-		}
-		boolean areWallsHollow = usedFlags.contains("hollow");
+		MazeBackup backup = sessionHandler.getBackup(maze);
+		Map<String, Integer> chestAmounts;
+		argValues.remove(0);
 
 		try {
-			setAsync(sender);
-			buildHandler.buildMaze(maze, settings, mazePart, areWallsHollow, () -> finishAsync(sender));
+			chestAmounts = deserializeLootChestPrefabs(argValues);
+			Map<String, BlockVec> addedChests = lootHandler.spawnChests(backup.getMazeMap(), chestAmounts, backup.getLootLocations().values());
+			backup.addLoot(addedChests);
 		} catch (TextException e) {
 			e.sendTextTo(sender);
-			finishAsync(sender);
-			return;
 		}
-		maze.setEditable(false);
-		toolHandler.resetClipTool(playerId);
-	}
 
-	private MazePart getMazePart(Set<String> usedFlags) {
-		if (usedFlags.contains("floor")) {
-			return MazePart.FLOOR;
-		} else if (usedFlags.contains("roof")) {
-			return MazePart.ROOF;
-		}
-		return MazePart.WALLS;
 	}
 
 	/**
 	 * Converts a list of material strings in the format "count(optional)*material:subId(optional)" into a BlockPalette.
+	 *
 	 * @param stringArgs the list of strings provided by the command sender
 	 * @return the BlockPalette created from the strings
 	 * @throws TextException if the strings are not in the correct format
 	 */
-	public BlockPalette deserializeBlockPalette(List<ArgValue> stringArgs) throws TextException {
-		BlockPalette palette = new BlockPalette();
-		
+	public Map<String, Integer> deserializeLootChestPrefabs(List<ArgValue> stringArgs) throws TextException {
+		Map<String, Integer> chestAmounts = new HashMap<>();
+
 		for (ArgValue input : stringArgs) {
 			String inputString = input.get();
 			int count = 1;
-			String materialString;
-			
+			String chestName;
+
 			if (inputString.contains("*")) {
 				String[] stringParts = inputString.split("\\*");
-				
+
 				if (stringParts.length < 1 || !MathUtil.isInt(stringParts[0])) {
 					throw new IllegalArgumentException("invalid input: " + inputString);
 				}
 				count = Integer.parseInt(stringParts[0]);
-				materialString = stringParts[1];
+				chestName = stringParts[1];
 			} else {
-				materialString = inputString;
+				chestName = inputString;
 			}
-			try {
-				BlockType blockType = BlockType.get(materialString, true);
-				palette.addBlock(blockType, MathUtil.clamp(count, 1, 1000));
-			} catch (IllegalArgumentException e) {
-				throw new TextException(Message.ERROR_INVALID_BLOCK_NAME, new Placeholder("block", materialString));
+			if (!lootHandler.chestExists(chestName)) {
+				//TODO add lang message
+				throw new TextException(Message.ERROR_INVALID_BLOCK_NAME, new Placeholder("block", chestName + " (chest)"));
 			}
+			Bukkit.broadcastMessage("spawn " + count + " * " + chestName);
+			chestAmounts.put(chestName, count);
 		}
-		return palette;
+		return chestAmounts;
 	}
-	
+
 	/**
 	 * Returns a list of block names that the sender could tab complete to.
 	 */
 	@Override
 	public List<String> getTabList(String[] stringArgs) {
 		List<String> tabList = super.getTabList(stringArgs);
-		
+
 		if (!tabList.isEmpty()) {
 			return tabList;
 		}
 		String tabbedArg = stringArgs[stringArgs.length - 1];
 		String factorString;
-		
+
 		if (tabbedArg.contains("*")) {
 			String[] stringParts = tabbedArg.split("\\*");
-			
+
 			if (stringParts.length < 1 || stringParts.length > 2 || !MathUtil.isInt(stringParts[0])) {
 				return tabList;
 			}
 			factorString = stringParts[0] + "*";
-			
+
 		} else if (MathUtil.isInt(tabbedArg)) {
 			factorString = tabbedArg + "*";
 		} else {
 			return MaterialUtil.getBlockNames();
 		}
-		
+
 		for (String blockName : MaterialUtil.getBlockNames()) {
 			tabList.add(factorString + blockName);
 		}

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
@@ -32,7 +32,7 @@ public class LootSpawnCommand extends ArgCommand {
 	private final boolean isAvailable;
 
 	public LootSpawnCommand(SessionHandler sessionHandler, LootHandler lootHandler, boolean isAvailable) {
-		super("loot");
+		super("spawn");
 		addArg(new Argument("x*chest...", ArgType.STRING));
 
 		this.sessionHandler = sessionHandler;
@@ -59,16 +59,18 @@ public class LootSpawnCommand extends ArgCommand {
 		}
 		MazeBackup backup = sessionHandler.getBackup(maze);
 		Map<String, Integer> chestAmounts;
-		argValues.remove(0);
+		Map<String, BlockVec> addedChests;
 
 		try {
 			chestAmounts = deserializeLootChestPrefabs(argValues);
-			Map<String, BlockVec> addedChests = lootHandler.spawnChests(backup.getMazeMap(), chestAmounts, backup.getLootLocations().values());
-			backup.addLoot(addedChests);
+			addedChests = lootHandler.spawnChests(backup.getMazeMap(), chestAmounts, backup.getLootLocations().values());
 		} catch (TextException e) {
 			e.sendTextTo(sender);
+			return;
 		}
-
+		backup.addLootLocations(addedChests);
+		sender.sendMessage("Placed total " + backup.getLootLocations().size() + " chests");
+		Bukkit.getPluginManager().callEvent(new LootChangeEvent(maze));
 	}
 
 	/**
@@ -101,7 +103,6 @@ public class LootSpawnCommand extends ArgCommand {
 				//TODO add lang message
 				throw new TextException(Message.ERROR_INVALID_BLOCK_NAME, new Placeholder("block", chestName + " (chest)"));
 			}
-			Bukkit.broadcastMessage("spawn " + count + " * " + chestName);
 			chestAmounts.put(chestName, count);
 		}
 		return chestAmounts;

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/UnbuildListener.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/UnbuildListener.java
@@ -1,0 +1,27 @@
+package me.gorgeousone.tangledmaze.loot;
+
+import me.gorgeousone.tangledmaze.event.MazeUnbuildEvent;
+import me.gorgeousone.tangledmaze.maze.MazePart;
+import me.gorgeousone.tangledmaze.util.text.TextException;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import java.util.logging.Level;
+
+public class UnbuildListener implements Listener {
+
+	private final LootHandler lootHandler;
+
+	public UnbuildListener(LootHandler lootHandler) {
+		this.lootHandler = lootHandler;
+	}
+
+	@EventHandler
+	public void onMazeUnbuild(MazeUnbuildEvent event) {
+		if (event.getMazePart() != MazePart.WALLS) {
+			return;
+		}
+		lootHandler.removeChests(event.getMaze());
+	}
+}

--- a/src/main/java/me/gorgeousone/tangledmaze/maze/MazeBackup.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/maze/MazeBackup.java
@@ -27,7 +27,7 @@ public class MazeBackup {
 	private MazeMap mazeMap;
 	private final Map<MazePart, BlockCollection> partBlockLocs;
 	private final Map<MazePart, Set<BlockLocType>> partBlocksTypes;
-	private final Map<String, BlockVec> lootLocations;
+	private Map<String, BlockVec> lootLocations;
 
 	public MazeBackup(Clip maze, MazeSettings settings) {
 		this.maze = maze;
@@ -103,15 +103,25 @@ public class MazeBackup {
 		mazeMap = null;
 	}
 
-	public void addLoot(Map<String, BlockVec> chestLocations) {
+	public void addLootLocations(Map<String, BlockVec> chestLocations) {
+		if (lootLocations == null) {
+			lootLocations = new HashMap<>();
+		}
 		lootLocations.putAll(chestLocations);
 	}
 
-	public void removeLoot() {
+	public void clearLootLocations() {
+		if (lootLocations == null) {
+			lootLocations = new HashMap<>();
+		}
 		lootLocations.clear();
 	}
 
 	public Map<String, BlockVec> getLootLocations() {
+		//workaround to load maze backups from <2.5.0
+		if (lootLocations == null) {
+			lootLocations = new HashMap<>();
+		}
 		return new HashMap<>(lootLocations);
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/maze/MazeBackup.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/maze/MazeBackup.java
@@ -5,6 +5,7 @@ import me.gorgeousone.tangledmaze.generation.BlockCollection;
 import me.gorgeousone.tangledmaze.generation.MazeMap;
 import me.gorgeousone.tangledmaze.generation.MazeMapFactory;
 import me.gorgeousone.tangledmaze.util.BlockUtil;
+import me.gorgeousone.tangledmaze.util.BlockVec;
 import me.gorgeousone.tangledmaze.util.VersionUtil;
 import me.gorgeousone.tangledmaze.util.blocktype.BlockLocType;
 
@@ -26,12 +27,14 @@ public class MazeBackup {
 	private MazeMap mazeMap;
 	private final Map<MazePart, BlockCollection> partBlockLocs;
 	private final Map<MazePart, Set<BlockLocType>> partBlocksTypes;
-	
+	private final Map<String, BlockVec> lootLocations;
+
 	public MazeBackup(Clip maze, MazeSettings settings) {
 		this.maze = maze;
 		this.settings = settings;
 		partBlockLocs = new HashMap<>();
 		partBlocksTypes = new HashMap<>();
+		lootLocations = new HashMap<>();
 	}
 	
 	public Clip getMaze() {
@@ -59,7 +62,7 @@ public class MazeBackup {
 	public BlockCollection getPartBlockLocs(MazePart mazePart) {
 		return partBlockLocs.get(mazePart);
 	}
-	
+
 	public void computeSegmentsIfAbsent(MazePart mazePart, Function<MazePart, BlockCollection> mappingFunction) {
 		partBlockLocs.computeIfAbsent(mazePart, mappingFunction);
 	}
@@ -98,5 +101,17 @@ public class MazeBackup {
 		partBlockLocs.clear();
 		partBlocksTypes.clear();
 		mazeMap = null;
+	}
+
+	public void addLoot(Map<String, BlockVec> chestLocations) {
+		lootLocations.putAll(chestLocations);
+	}
+
+	public void removeLoot() {
+		lootLocations.clear();
+	}
+
+	public Map<String, BlockVec> getLootLocations() {
+		return new HashMap<>(lootLocations);
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/maze/MazePart.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/maze/MazePart.java
@@ -4,5 +4,5 @@ package me.gorgeousone.tangledmaze.maze;
  * An enum to distinguish between different parts of a maze.
  */
 public enum MazePart {
-	WALLS, FLOOR, ROOF, LOOT_CHESTS;
+	WALLS, FLOOR, ROOF
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/maze/MazePart.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/maze/MazePart.java
@@ -4,5 +4,5 @@ package me.gorgeousone.tangledmaze.maze;
  * An enum to distinguish between different parts of a maze.
  */
 public enum MazePart {
-	WALLS, FLOOR, ROOF
+	WALLS, FLOOR, ROOF, LOOT_CHESTS;
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/util/BlockVec.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/util/BlockVec.java
@@ -45,7 +45,7 @@ public class BlockVec {
 		this.z = z;
 	}
 	
-	public Location toLoc(World world) {
+	public Location toLocation(World world) {
 		return new Location(world, x, y, z);
 	}
 	

--- a/src/main/java/me/gorgeousone/tangledmaze/util/Direction.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/util/Direction.java
@@ -1,45 +1,49 @@
 package me.gorgeousone.tangledmaze.util;
 
+import org.bukkit.block.BlockFace;
+
 public enum Direction {
 	
-	EAST(new Vec2(1, 0)),
-	SOUTH_EAST(new Vec2(1, 1)),
-	SOUTH(new Vec2(0, 1)),
-	SOUTH_WEST(new Vec2(-1, 1)),
-	WEST(new Vec2(-1, 0)),
-	NORTH_WEST(new Vec2(-1, -1)),
-	NORTH(new Vec2(0, -1)),
-	NORTH_EAST(new Vec2(1, -1));
+	EAST(new Vec2(1, 0), BlockFace.EAST),
+	SOUTH_EAST(new Vec2(1, 1), BlockFace.SOUTH_EAST),
+	SOUTH(new Vec2(0, 1), BlockFace.SOUTH),
+	SOUTH_WEST(new Vec2(-1, 1), BlockFace.SOUTH_WEST),
+	WEST(new Vec2(-1, 0), BlockFace.WEST),
+	NORTH_WEST(new Vec2(-1, -1), BlockFace.NORTH_WEST),
+	NORTH(new Vec2(0, -1), BlockFace.NORTH),
+	NORTH_EAST(new Vec2(1, -1), BlockFace.NORTH_EAST);
 	
 	public static final Direction[] CARDINALS = {EAST, SOUTH, WEST, NORTH};
 	public static final Direction[] DIAGONALS = {SOUTH_EAST, SOUTH_WEST, NORTH_WEST, NORTH_EAST};
 	
-	private final Vec2 facing;
+	private final Vec2 dirVec;
+	private final BlockFace face;
 
-	Direction(Vec2 facing) {
-		this.facing = facing;
+	Direction(Vec2 dirVec, BlockFace face) {
+		this.dirVec = dirVec;
+		this.face = face;
 	}
 	
 	/**
 	 * Returns true if the direction's vector is pointing towards positive (with it's x and z coordinate)
 	 */
 	public boolean isPositive() {
-		return facing.getZ() >= 0 && facing.getX() >= 0;
+		return dirVec.getZ() >= 0 && dirVec.getX() >= 0;
 	}
 	
 	/**
 	 * Returns if the x coordinate of the direction's vector is not 0
 	 */
 	public boolean isCollinearX() {
-		return facing.getZ() == 0;
+		return dirVec.getZ() == 0;
 	}
 	
 	public boolean isCollinearZ() {
-		return facing.getX() == 0;
+		return dirVec.getX() == 0;
 	}
 	
 	public Vec2 getVec2() {
-		return facing.clone();
+		return dirVec.clone();
 	}
 	
 	public Direction getOpposite() {
@@ -64,5 +68,9 @@ public enum Direction {
 		}
 		int diff = Math.floorMod(other.ordinal() - ordinal() + 4, 8) - 4;
 		return values()[Math.floorMod(ordinal() + diff / 2, 8)];
+	}
+
+	public BlockFace getFace() {
+		return face;
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/util/Vec2.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/util/Vec2.java
@@ -56,35 +56,35 @@ public class Vec2 implements Comparable<Vec2> {
 	public Vec2 sub(Vec2 other) {
 		return sub(other.x, other.z);
 	}
-	
+
 	public Vec2 sub(int dx, int dz) {
 		x -= dx;
 		z -= dz;
 		return this;
 	}
-	
+
 	public Location toLocation(World world, int y) {
 		return new Location(world, x, y, z);
 	}
-	
+
 	public Vec2 mult(int scalar) {
 		x *= scalar;
 		z *= scalar;
 		return this;
 	}
-	
+
 	public Vec2 floorDiv(int scalar) {
 		x = Math.floorDiv(x, scalar);
 		z = Math.floorDiv(z, scalar);
 		return this;
 	}
-	
+
 	public Vec2 floorMod(int scalar) {
 		x = Math.floorMod(x, scalar);
 		z = Math.floorMod(z, scalar);
 		return this;
 	}
-	
+
 	@Override
 	public int compareTo(Vec2 vec) {
 		int deltaX = Double.compare(getX(), vec.getX());
@@ -109,7 +109,7 @@ public class Vec2 implements Comparable<Vec2> {
 	public Vec2 clone() {
 		return new Vec2(x, z);
 	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -122,12 +122,12 @@ public class Vec2 implements Comparable<Vec2> {
 		return x == vec.x &&
 		       z == vec.z;
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return Objects.hash(x, z);
 	}
-	
+
 	@Override
 	public String toString() {
 		return "[" + "x=" + x + ", z=" + z + ']';

--- a/src/main/java/me/gorgeousone/tangledmaze/util/blocktype/BlockType.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/util/blocktype/BlockType.java
@@ -45,11 +45,14 @@ public abstract class BlockType {
 	public static BlockType get(BlockState state) {
 		return isLegacyServer ? new BlockTypeLegacy(state) : new BlockTypeAquatic(state);
 	}
-	
+
 	public static BlockType get(String serialized) {
 		return get(serialized, false);
 	}
-	
+
+	public static BlockType get(String serialized, String legacySerialized) {
+		return isLegacyServer ? new BlockTypeLegacy(legacySerialized) : new BlockTypeAquatic(serialized, false);
+	}
 	public static BlockType get(String serialized, boolean randomizeFacing) {
 		return isLegacyServer ? new BlockTypeLegacy(serialized) : new BlockTypeAquatic(serialized, randomizeFacing);
 	}


### PR DESCRIPTION
Had success with hackily hooking the LootChest plugin by Guardmanda/balck_eyes to spawn loot chests in mazes.

Added a command /tm lood [spawn/respawn/remove] to spawn and manage cpoies of prefab chests (so far only in maze rooms).
Unbuilding mazes automatically removes chests, autosaving is triggered as well after changes to chests.

Upcoming:
* proper messages
* cmd options to spawn chests everywhere, in rooms or dead ends?

![screen2](https://github.com/GorgeousOne/Tangled-Maze-2/assets/27733909/55411b61-dbd0-483d-9fe3-c84edaa1e10b)
