### PR TITLE
 Added customoizable loot locations to loot spawn command

### DIFF
--- a/src/main/java/me/gorgeousone/tangledmaze/generation/GridCell.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/GridCell.java
@@ -4,7 +4,9 @@ import me.gorgeousone.tangledmaze.generation.paving.PathTree;
 import me.gorgeousone.tangledmaze.util.Direction;
 import me.gorgeousone.tangledmaze.util.Vec2;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -12,80 +14,81 @@ import java.util.Set;
  * A class that
  */
 public class GridCell {
-	
+
 	private final Vec2 min;
 	private final Vec2 max;
 	private final Vec2 gridPos;
-	
+
 	private transient PathTree tree;
 	private transient GridCell parent;
-	
+
 	public GridCell(Vec2 min, Vec2 size, Vec2 gridPos) {
 		this.min = min.clone();
 		this.max = min.clone().add(size);
 		this.gridPos = gridPos;
 	}
-	
+
 	public Vec2 getGridPos() {
 		return gridPos.clone();
 	}
-	
+
 	public int gridX() {
 		return gridPos.getX();
 	}
-	
+
 	public int gridZ() {
 		return gridPos.getZ();
 	}
-	
+
 	public Vec2 getMin() {
 		return min.clone();
 	}
-	
+
 	public Vec2 getMax() {
 		return max.clone();
 	}
-	
+
 	public boolean contains(Vec2 pos) {
 		return contains(pos.getX(), pos.getZ());
 	}
-	
+
 	public boolean contains(int x, int z) {
 		return x >= min.getX() && x < max.getX() &&
-		       z >= min.getZ() && z < max.getZ();
+				z >= min.getZ() && z < max.getZ();
 	}
-	
+
 	public PathTree getTree() {
 		return tree;
 	}
-	
+
 	public void setTree(PathTree tree) {
 		this.tree = tree;
 	}
-	
+
 	public boolean hasParent() {
 		return parent != null;
 	}
-	
+
 	public GridCell getParent() {
 		return parent;
 	}
-	
+
 	public void setParent(GridCell parent) {
 		this.parent = parent;
 	}
-	
+
 	/**
 	 * Returns a set of directions in which the world x and z coordinate are border of the grid cell
+	 *
 	 * @param x world x coordinate inside a grid cell
 	 * @param z world z coordinate inside a grid cell
 	 */
 	public Set<Direction> getWallFacings(int x, int z) {
 		Set<Direction> facings = new HashSet<>();
-		
+
 		if (x == min.getX()) {
 			facings.add(Direction.WEST);
-			
+
 			if (z == min.getZ()) {
 				facings.add(Direction.NORTH_WEST);
 			}
@@ -95,7 +98,7 @@ public class GridCell {
 		}
 		if (x == max.getX() - 1) {
 			facings.add(Direction.EAST);
-			
+
 			if (z == min.getZ()) {
 				facings.add(Direction.NORTH_EAST);
 			}
@@ -112,12 +115,12 @@ public class GridCell {
 		return facings;
 	}
 
-	public Set<Vec2> getWalls(Direction direction) {
+	public List<Vec2> getWalls(Direction direction) {
 		Vec2 iter = direction.isPositive() ? min.clone() : max.clone().add(-1, -1);
 		Vec2 step = direction.getVec2();
 		Vec2 cellSize = max.clone().sub(min);
 		int limit = direction.isCollinearX() ? cellSize.getX() : cellSize.getZ();
-		Set<Vec2> walls = new HashSet<>();
+		List<Vec2> walls = new ArrayList<>();
 
 		for (int i = 0; i < limit; ++i) {
 			walls.add(iter.clone());
@@ -125,7 +128,7 @@ public class GridCell {
 		}
 		return walls;
 	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -137,18 +140,18 @@ public class GridCell {
 		GridCell gridCell = (GridCell) o;
 		return Objects.equals(gridPos, gridCell.gridPos);
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return gridPos.hashCode();
 	}
-	
+
 	@Override
 	public String toString() {
 		return "[" +
-		       "grid=" + gridPos +
-		       ", min=" + min +
-		       ", max=" + max +
-		       ']';
+				"grid=" + gridPos +
+				", min=" + min +
+				", max=" + max +
+				']';
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/GridMap.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/GridMap.java
@@ -340,7 +340,7 @@ public class GridMap {
 		List<Direction> wallDirs = new ArrayList<>();
 
 		for (Direction dir : Direction.CARDINALS) {
-			if (getPathType(gridPos.clone().add(dir.getVec2())) == PathType.BLOCKED) {
+			if (getPathType(gridPos.clone().add(dir.getVec2())) != PathType.PAVED) {
 				wallDirs.add(dir);
 			}
 		}
@@ -348,13 +348,11 @@ public class GridMap {
 	}
 
 	public boolean isDeadEnd(int x, int z) {
-		if (getPathType(x, z) != PathType.PAVED) {
-			return false;
-		}
 		int pathNeighbors = 0;
 
 		for (Direction dir : Direction.CARDINALS) {
-			if (getPathType(x + dir.getX(), z + dir.getZ()) == PathType.PAVED) {
+			PathType pathType = getPathType(x + dir.getX(), z + dir.getZ());
+			if (pathType == PathType.PAVED || pathType == PathType.ROOM) {
 				++pathNeighbors;
 			}
 		}

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/GridMap.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/GridMap.java
@@ -17,26 +17,25 @@ import java.util.List;
  * (junctions: path width x path width, paths: wall x path / path x wall, walls: wall x wall).
  */
 public class GridMap {
-	
+
 	private final Vec2 mapMin;
 	private final Vec2 mapMax;
 	private final int pathWidth;
 	private final int wallWidth;
 	private final int gridMeshSize;
-	
+
 	private Vec2 gridMin;
 	private Vec2 gridOffset;
 	private GridCell[][] gridCells;
-	
+
 	private PathType[][] pathTypes;
 	private int[][] floorYs;
 	private int[][] wallYs;
-	
+
 	private final List<ExitSegment> exits;
 	private final List<GridCell> pathStarts;
 	private final List<Room> rooms;
 
-	
 	public GridMap(Vec2 mapMin,
 	               Vec2 mapMax,
 	               int pathWidth,
@@ -50,23 +49,23 @@ public class GridMap {
 		pathStarts = new ArrayList<>();
 		rooms = new ArrayList<>();
 	}
-	
+
 	public int getWidth() {
 		return gridCells.length;
 	}
-	
+
 	public int getHeight() {
 		return gridCells[0].length;
 	}
-	
+
 	public List<ExitSegment> getExits() {
 		return new ArrayList<>(exits);
 	}
-	
+
 	public List<GridCell> getPathStarts() {
 		return pathStarts;
 	}
-	
+
 	/**
 	 * Returns the grid coordinates of the grid cell that is located at this world location
 	 */
@@ -109,7 +108,7 @@ public class GridMap {
 		}
 		return null;
 	}
-	
+
 	public void setPathType(Vec2 gridPos, PathType type) {
 		setPathType(gridPos.getX(), gridPos.getZ(), type);
 	}
@@ -127,11 +126,11 @@ public class GridMap {
 		}
 		return floorYs[gridPos.getX()][gridPos.getZ()];
 	}
-	
+
 	public void setFloorY(int gridX, int gridZ, int y) {
 		floorYs[gridX][gridZ] = y;
 	}
-	
+
 	/**
 	 * Returns the collective y height for all wall columns in this cell
 	 * Returns 0 if not set
@@ -142,30 +141,27 @@ public class GridMap {
 		}
 		return wallYs[gridPos.getX()][gridPos.getZ()];
 	}
-	
+
 	/**
 	 * Sets the top y coordinate of a grid...
-	 * @param gridX
-	 * @param gridZ
-	 * @param y
 	 */
 	public void setWallY(int gridX, int gridZ, int y) {
 		wallYs[gridX][gridZ] = y;
 	}
-	
+
 	public void setPathType(int gridX, int gridZ, PathType type) {
 		pathTypes[gridX][gridZ] = type;
 	}
-	
+
 	public boolean contains(Vec2 gridPos) {
 		return contains(gridPos.getX(), gridPos.getZ());
 	}
-	
+
 	public boolean contains(int gridX, int gridZ) {
 		return gridX >= 0 && gridX < getWidth() &&
-		       gridZ >= 0 && gridZ < getHeight();
+				gridZ >= 0 && gridZ < getHeight();
 	}
-	
+
 	/**
 	 * Sets the entrance segment of the grid map and calculates all the grid properties based on that
 	 */
@@ -174,15 +170,15 @@ public class GridMap {
 		ExitSegment entrance = new ExitSegment(entranceStart, facing, pathWidth);
 		entrance.extend(wallWidth);
 		exits.add(entrance);
-		
+
 		Vec2 entranceEnd = entrance.getEnd();
 		calculateGridProperties(entranceEnd);
-		
+
 		Vec2 entranceGridPos = getGridPos(entranceEnd);
 		setPathType(entranceGridPos, PathType.PAVED);
 		pathStarts.add(getCell(entranceGridPos));
 	}
-	
+
 	/**
 	 * Creates an exit segment extending to the next grid cell.
 	 * Then optionally creates a left or right turn in order to perfectly end on a path conjunction
@@ -191,11 +187,11 @@ public class GridMap {
 		Vec2 exitStart = calculateExitStart(exitBlockLoc, facing, pathWidth);
 		ExitSegment exit = new ExitSegment(exitStart, facing, pathWidth);
 		exit.extend(getDistToPathGrid(exit.getEnd(), facing, false));
-		
+
 		Vec2 exitEnd = exit.getEnd();
 		Direction left = facing.getLeft();
 		Direction right = facing.getRight();
-		
+
 		ExitSegment leftTurn = new ExitSegment(exitEnd, left, pathWidth);
 		ExitSegment rightTurn = new ExitSegment(exitEnd, right, pathWidth);
 		leftTurn.extend(getDistToPathGrid(leftTurn.getEnd(), left, true));
@@ -203,17 +199,17 @@ public class GridMap {
 
 		boolean leftIsFree = Arrays.asList(PathType.PAVED, PathType.FREE).contains(getPathType(getGridPos(leftTurn.getEnd())));
 		boolean rightIsFree = Arrays.asList(PathType.PAVED, PathType.FREE).contains(getPathType(getGridPos(leftTurn.getEnd())));
-		
+
 		if (!leftIsFree && !rightIsFree) {
 			return;
 		}
 		ExitSegment chosenTurn;
-		
+
 		if (leftIsFree && rightIsFree) {
 			boolean chooseLeft = leftTurn.length() > rightTurn.length();
 			chosenTurn = chooseLeft ? leftTurn : rightTurn;
 			ExitSegment otherTurn = chooseLeft ? rightTurn : leftTurn;
-			
+
 			//places a blocked path at tje opposite side of chosen turn
 			//to prevent path generator to connect a second path to the exit
 			if (otherTurn.length() > otherTurn.width() && otherTurn.length() < 2 * otherTurn.width() + 1) {
@@ -245,14 +241,14 @@ public class GridMap {
 	public List<Room> getRooms() {
 		return new ArrayList<>(rooms);
 	}
-	
+
 	/**
 	 * Calculates the location of the exit segment start so that any exits bigger than 1 block are always
 	 * aligned towards the right of the selected exit block, independent of faced direction.
 	 */
 	private Vec2 calculateExitStart(Vec2 exitBlockLoc, Direction facing, int exitWidth) {
 		Vec2 exitStart = exitBlockLoc.clone();
-		
+
 		if (!facing.isPositive()) {
 			exitStart.sub(0, exitWidth - 1);
 		}
@@ -261,9 +257,10 @@ public class GridMap {
 		}
 		return exitStart;
 	}
-	
+
 	/**
 	 * Calculates the distance in blocks that a secondary exit has to be extended by for it to reach the nearest grid path
+	 *
 	 * @param exitLoc   current end location of the exit
 	 * @param facing    direction to extend towards
 	 * @param allowZero set false if returned distance must be greater than 0
@@ -271,7 +268,7 @@ public class GridMap {
 	private int getDistToPathGrid(Vec2 exitLoc, Direction facing, boolean allowZero) {
 		int gridShift;
 		int exitCoord;
-		
+
 		if (facing.isCollinearX()) {
 			gridShift = gridOffset.getX();
 			exitCoord = exitLoc.getX();
@@ -281,7 +278,7 @@ public class GridMap {
 		}
 		int gridMeshSize = pathWidth + wallWidth;
 		int gridDist = Math.floorMod(exitCoord - gridShift, gridMeshSize);
-		
+
 		if (facing.isPositive()) {
 			gridDist = (gridMeshSize - gridDist) % gridMeshSize;
 		}
@@ -290,7 +287,7 @@ public class GridMap {
 		}
 		return gridDist;
 	}
-	
+
 	/**
 	 * Calculates position and count of rows and columns of the path grid
 	 */
@@ -298,22 +295,22 @@ public class GridMap {
 		gridOffset = new Vec2(
 				pathStart.getX() % gridMeshSize,
 				pathStart.getZ() % gridMeshSize);
-		
+
 		gridMin = mapMin.clone().sub(gridOffset);
 		gridMin.floorDiv(gridMeshSize).mult(gridMeshSize);
 		gridMin.add(gridOffset);
-		
+
 		int gridWidth = 2 * (int) Math.ceil(1f * (mapMax.getX() - gridMin.getX()) / gridMeshSize);
 		int gridHeight = 2 * (int) Math.ceil(1f * (mapMax.getZ() - gridMin.getZ()) / gridMeshSize);
 		createGridCells(gridWidth, gridHeight);
 	}
-	
+
 	private void createGridCells(int gridWidth, int gridHeight) {
 		gridCells = new GridCell[gridWidth][gridHeight];
 		pathTypes = new PathType[gridWidth][gridHeight];
 		floorYs = new int[gridWidth][gridHeight];
 		wallYs = new int[gridWidth][gridHeight];
-		
+
 		for (int gridX = 0; gridX < getWidth(); ++gridX) {
 			for (int gridZ = 0; gridZ < getHeight(); ++gridZ) {
 				gridCells[gridX][gridZ] = createGridSegment(gridX, gridZ);
@@ -321,10 +318,10 @@ public class GridMap {
 			}
 		}
 	}
-	
+
 	private GridCell createGridSegment(int gridX, int gridZ) {
 		Vec2 segmentStart = gridMin.clone();
-		
+
 		segmentStart.add(
 				(gridX / 2) * gridMeshSize,
 				(gridZ / 2) * gridMeshSize);
@@ -334,7 +331,33 @@ public class GridMap {
 		Vec2 segmentSize = new Vec2(
 				gridX % 2 == 0 ? pathWidth : wallWidth,
 				gridZ % 2 == 0 ? pathWidth : wallWidth);
-		
+
 		return new GridCell(segmentStart, segmentSize, new Vec2(gridX, gridZ));
+	}
+
+	public List<Direction> getWallDirs(GridCell cell) {
+		Vec2 gridPos = cell.getGridPos();
+		List<Direction> wallDirs = new ArrayList<>();
+
+		for (Direction dir : Direction.CARDINALS) {
+			if (getPathType(gridPos.clone().add(dir.getVec2())) == PathType.BLOCKED) {
+				wallDirs.add(dir);
+			}
+		}
+		return wallDirs;
+	}
+
+	public boolean isDeadEnd(int x, int z) {
+		if (getPathType(x, z) != PathType.PAVED) {
+			return false;
+		}
+		int pathNeighbors = 0;
+
+		for (Direction dir : Direction.CARDINALS) {
+			if (getPathType(x + dir.getX(), z + dir.getZ()) == PathType.PAVED) {
+				++pathNeighbors;
+			}
+		}
+		return pathNeighbors == 1;
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
@@ -67,21 +67,8 @@ public class Room {
 	}
 
 	public boolean borderContains(int gridX, int gridZ) {
-		return gridX == gridMin.getX() || gridX == gridMax.getX() ||
-				gridZ == gridMin.getZ() || gridZ == gridMax.getZ();
-	}
-
-	public Direction getWallFacing(Vec2 gridPos) {
-		if (gridPos.getZ() == gridMin.getZ()) {
-			return Direction.NORTH;
-		} else if (gridPos.getZ() == gridMax.getZ() - 1) {
-			return Direction.SOUTH;
-		} else if (gridPos.getX() == gridMin.getX()) {
-			return Direction.WEST;
-		} else if (gridPos.getX() == gridMax.getX() - 1) {
-			return Direction.EAST;
-		}
-		return null;
+		return gridX == gridMin.getX() || gridX == gridMax.getX() - 1 ||
+				gridZ == gridMin.getZ() || gridZ == gridMax.getZ() - 1;
 	}
 
 	public void floodFillRoom(GridCell startCell, GridMap gridMap) {

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
@@ -58,10 +58,17 @@ public class Room {
 	}
 
 	public boolean contains(Vec2 gridPos) {
-		return gridPos.getX() >= gridMin.getX() &&
-		       gridPos.getZ() >= gridMin.getZ() &&
-		       gridPos.getX() < gridMax.getX() &&
-		       gridPos.getZ() < gridMax.getZ();
+		return contains(gridPos.getX(), gridPos.getZ());
+	}
+
+	public boolean contains(int gridX, int gridZ) {
+		return gridX >= gridMin.getX() && gridX < gridMax.getX() &&
+				gridZ >= gridMin.getZ() && gridZ < gridMax.getZ();
+	}
+
+	public boolean borderContains(int gridX, int gridZ) {
+		return gridX == gridMin.getX() || gridX == gridMax.getX() ||
+				gridZ == gridMin.getZ() || gridZ == gridMax.getZ();
 	}
 
 	public Direction getWallFacing(Vec2 gridPos) {

--- a/src/main/java/me/gorgeousone/tangledmaze/listener/ClickListener.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/listener/ClickListener.java
@@ -208,8 +208,7 @@ public class ClickListener implements Listener {
 		updatedBlocks.add(new Vec2(clickedBlock));
 
 		for (Direction dir : Direction.CARDINALS) {
-			Vec2 facing = dir.getVec2();
-			updatedBlocks.add(new Vec2(clickedBlock.getRelative(facing.getX(), 0, facing.getZ())));
+			updatedBlocks.add(new Vec2(clickedBlock.getRelative(dir.getX(), 0, dir.getZ())));
 		}
 		new BukkitRunnable() {
 			@Override

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootChestLocator.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootChestLocator.java
@@ -67,7 +67,7 @@ public class LootChestLocator {
 
 			for (Direction dir : wallDirs) {
 				for (Vec2 block : cell.getWalls(dir)) {
-					blocks.put(block, dir);
+					blocks.put(block, dir.getOpposite());
 				}
 			}
 			blocks.keySet().removeAll(occupiedBlocks);
@@ -76,7 +76,10 @@ public class LootChestLocator {
 				availableCells.remove(cell);
 				continue;
 			}
-			Vec2 rndBlock = blocks.keySet().stream().skip(RND.nextInt(blocks.size())).findFirst().orElse(null);
+			Vec2 rndBlock = blocks.keySet().stream()
+					.skip(RND.nextInt(blocks.size()))
+					.findFirst()
+					.orElse(null);
 			spawns.put(rndBlock, blocks.get(rndBlock));
 			markOccupiedSpawns(occupiedBlocks, rndBlock);
 		}

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootChestLocator.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootChestLocator.java
@@ -3,48 +3,107 @@ package me.gorgeousone.tangledmaze.loot;
 import me.gorgeousone.tangledmaze.generation.GridCell;
 import me.gorgeousone.tangledmaze.generation.GridMap;
 import me.gorgeousone.tangledmaze.generation.MazeMap;
+import me.gorgeousone.tangledmaze.generation.paving.PathType;
 import me.gorgeousone.tangledmaze.generation.paving.Room;
-import me.gorgeousone.tangledmaze.util.BlockVec;
 import me.gorgeousone.tangledmaze.util.Direction;
 import me.gorgeousone.tangledmaze.util.Vec2;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 
 public class LootChestLocator {
 
-	/**
-	 * @return map of non-junction grid cells in all rooms mapped to facing direction
-	 */
-	public static Map<Vec2, Direction> findRoomWallCells(MazeMap mazeMap) {
-		GridMap gridMap = mazeMap.getPathMap();
-		List<Room> rooms = gridMap.getRooms();
-		Map<Vec2, Direction> blocks = new HashMap<>();
+	private static final Random RND = new Random();
 
-		for (Room room : rooms) {
-			for (Vec2 gridPos : room.getBorderCells()) {
-				if (isJunction(gridPos)) {
+	public static List<GridCell> getAvailableCells(
+			MazeMap mazeMap,
+			boolean isLootInHallways,
+			boolean isLootInDeadEnds,
+			boolean isLootInRooms) {
+		GridMap gridMap = mazeMap.getPathMap();
+		List<GridCell> availableCells = new ArrayList<>();
+		List<Room> rooms = gridMap.getRooms();
+
+		for (int x = 0; x < gridMap.getWidth(); ++x) {
+			for (int z = 0; z < gridMap.getHeight(); ++z) {
+				if (!isPath(x, z) || gridMap.getPathType(x, z) != PathType.PAVED) {
 					continue;
 				}
-				GridCell cell = gridMap.getCell(gridPos);
-				Direction facing = room.getWallFacing(gridPos);
-				blocks.putAll(getWallPositions(cell, facing.getOpposite(), mazeMap));
+				boolean isRoom = isAnyRoomBorder(rooms, x, z);
+
+				if (!isLootInRooms && isRoom) {
+					continue;
+				}
+				boolean isDeadEnd = !isRoom && gridMap.isDeadEnd(x, z);
+
+				if (!isLootInDeadEnds && isDeadEnd) {
+					continue;
+				}
+				if (isDeadEnd) {
+					System.out.println("dead " + x + " " + z);
+				}
+				if (!isLootInHallways && (isRoom || isDeadEnd)) {
+					continue;
+				}
+				availableCells.add(gridMap.getCell(x, z));
 			}
 		}
-		return blocks;
+		return availableCells;
 	}
 
-	private static boolean isJunction(Vec2 gridPos) {
-		return gridPos.getX() % 2 == 0 && gridPos.getZ() % 2 == 0;
-	}
+	public static Map<Vec2, Direction> findChestSpawns(int chestCount, List<GridCell> availableCells, GridMap gridMap, Set<Vec2> existingSpawns) {
+		Set<Vec2> occupiedBlocks = new HashSet<>();
+		existingSpawns.forEach(v -> markOccupiedSpawns(occupiedBlocks, v));
+		Map<Vec2, Direction> spawns = new HashMap<>();
+		int spawnAttempts = 1000;
 
-	private static Map<Vec2, Direction> getWallPositions(GridCell cell, Direction direction, MazeMap mazeMap) {
-		Map<Vec2, Direction> wallBlocks = new HashMap<>();
+		System.out.println("check" + availableCells.size());
+		while (spawnAttempts > 0 && spawns.size() < chestCount && !availableCells.isEmpty()) {
+			--spawnAttempts;
+			if (spawnAttempts % 100 == 0) {
+				System.out.println("attempt " + spawnAttempts);
+			}
+			GridCell cell = availableCells.get(RND.nextInt(availableCells.size()));
+			List<Direction> wallDirs = gridMap.getWallDirs(cell);
+			Map<Vec2, Direction> blocks = new HashMap<>();
 
-		for (Vec2 pos : cell.getWalls(direction)) {
-			wallBlocks.put(pos, direction);
+			for (Direction dir : wallDirs) {
+				for (Vec2 block : cell.getWalls(dir)) {
+					blocks.put(block, dir);
+				}
+			}
+			blocks.keySet().removeAll(occupiedBlocks);
+
+			if (blocks.isEmpty()) {
+				availableCells.remove(cell);
+				continue;
+			}
+			Vec2 rndBlock = blocks.keySet().stream().skip(RND.nextInt(blocks.size())).findFirst().orElse(null);
+			spawns.put(rndBlock, blocks.get(rndBlock));
+			markOccupiedSpawns(occupiedBlocks, rndBlock);
 		}
-		return wallBlocks;
+		return spawns;
+	}
+
+	/**
+	 * Returns true if the grid position is neither a junction (even, even) nor a wall (odd, odd)
+	 */
+	private static boolean isPath(int gridX, int gridZ) {
+		return gridX % 2 == 1 ^ gridZ % 2 == 1;
+	}
+
+	private static boolean isAnyRoomBorder(List<Room> rooms, int gridX, int gridZ) {
+		return rooms.stream().anyMatch(r -> r.borderContains(gridX, gridZ));
+	}
+
+	private static void markOccupiedSpawns(Set<Vec2> occupied, Vec2 spawn) {
+		for (Direction dir : Direction.CARDINALS) {
+			occupied.add(spawn.clone().add(dir.getVec2()));
+		}
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
@@ -64,6 +64,12 @@ public class LootHandler {
 		}
 	}
 
+	public List<String> getChestNames() {
+		return lootChestPlugin.getLootChest().keySet().stream()
+				.filter(s -> !s.startsWith("zz"))
+				.collect(Collectors.toList());
+	}
+
 	public boolean chestExists(String chestName) {
 		return lootChestPlugin.getLootChest().containsKey(chestName);
 	}

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootHandler.java
@@ -7,6 +7,7 @@ import fr.black_eyes.lootchest.Utils;
 import me.gorgeousone.tangledmaze.SessionHandler;
 import me.gorgeousone.tangledmaze.clip.Clip;
 import me.gorgeousone.tangledmaze.data.Message;
+import me.gorgeousone.tangledmaze.generation.GridCell;
 import me.gorgeousone.tangledmaze.generation.MazeMap;
 import me.gorgeousone.tangledmaze.maze.MazeBackup;
 import me.gorgeousone.tangledmaze.util.BlockVec;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class LootHandler {
 
@@ -65,31 +67,42 @@ public class LootHandler {
 		return lootChestPlugin.getLootChest().containsKey(chestName);
 	}
 
-	public Map<String, BlockVec> spawnChests(Clip maze, Map<String, Integer> chestAmounts) throws TextException {
+	public Map<String, BlockVec> spawnChests(
+			Clip maze,
+			Map<String, Integer> chestAmounts,
+			boolean isLootInHallways,
+			boolean isLootInDeadEnds,
+			boolean isLootInRooms) throws TextException {
 		if (!sessionHandler.isBuilt(maze)) {
 			throw new TextException(Message.INFO_MAZE_NOT_BUILT);
 		}
 		MazeBackup backup = sessionHandler.getBackup(maze);
 		MazeMap mazeMap = backup.getMazeMap();
+		Set<Vec2> existingpawns = backup.getLootLocations().values().stream().map(BlockVec::toVec2).collect(Collectors.toSet());
 
 		List<String> chestPrefabList = listChests(chestAmounts);
-		Map<Vec2, Direction> wallDirs = LootChestLocator.findRoomWallCells(mazeMap);
-		List<Vec2> walls = new ArrayList<>(wallDirs.keySet());
-
 		Collections.shuffle(chestPrefabList);
-		Collections.shuffle(walls);
+
+		List<GridCell> availableCells = LootChestLocator.getAvailableCells(
+				mazeMap,
+				isLootInHallways,
+				isLootInDeadEnds,
+				isLootInRooms);
+
+		Map<Vec2, Direction> chestSpawns = LootChestLocator.findChestSpawns(
+				chestPrefabList.size(),
+				availableCells,
+				mazeMap.getPathMap(),
+				existingpawns);
+
 		Map<String, BlockVec> addedChests = new HashMap<>();
 
-		while (!chestPrefabList.isEmpty() && !walls.isEmpty()) {
+		for (Vec2 pos : chestSpawns.keySet()) {
 			String prefabName = chestPrefabList.remove(0);
-			Vec2 wall = walls.remove(0);
-			int blockY = mazeMap.getY(wall) + 1;
-
-			Direction dir = wallDirs.get(wall);
-			removeNeighbors(walls, wall);
-
-			String copyName = spawnLootChest(prefabName, wall.toLocation(mazeMap.getWorld(), blockY), dir.getFace());
-			addedChests.put(copyName, new BlockVec(wall, blockY));
+			int blockY = mazeMap.getY(pos) + 1;
+			Direction dir = chestSpawns.get(pos);
+			String copyName = spawnLootChest(prefabName, pos.toLocation(mazeMap.getWorld(), blockY), dir.getFace());
+			addedChests.put(copyName, new BlockVec(pos, blockY));
 		}
 		//write all chests to the config and save the file
 		lootChestPlugin.getConfigFiles().saveData();

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootRemoveCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootRemoveCommand.java
@@ -39,6 +39,7 @@ public class LootRemoveCommand extends BaseCommand {
 			return;
 		}
 		int removedChestCount = lootHandler.removeChests(maze);
+		//TODO jsonfy
 		sender.sendMessage("remove " + removedChestCount + " chests");
 	}
 }

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
@@ -34,6 +34,9 @@ public class LootSpawnCommand extends ArgCommand {
 	public LootSpawnCommand(SessionHandler sessionHandler, LootHandler lootHandler, boolean isAvailable) {
 		super("spawn");
 		addArg(new Argument("x*chest...", ArgType.STRING));
+		addFlag("hallways");
+		addFlag("deadends");
+		addFlag("rooms");
 
 		this.sessionHandler = sessionHandler;
 		this.lootHandler = lootHandler;
@@ -55,10 +58,19 @@ public class LootSpawnCommand extends ArgCommand {
 		}
 		Map<String, Integer> chestAmounts;
 		Map<String, BlockVec> addedChests;
+		boolean isLootInHallways = usedFlags.contains("hallways");
+		boolean isLootInDeadEnds = usedFlags.contains("deadends");
+		boolean isLootInRooms = usedFlags.contains("rooms");
 
+		if (!isLootInHallways && !isLootInDeadEnds && !isLootInRooms) {
+			isLootInHallways = isLootInDeadEnds = isLootInRooms = true;
+		}
+		sender.sendMessage("hall " + isLootInHallways);
+		sender.sendMessage("dead " + isLootInDeadEnds);
+		sender.sendMessage("room " + isLootInRooms);
 		try {
 			chestAmounts = deserializeLootChestPrefabs(argValues);
-			addedChests = lootHandler.spawnChests(maze, chestAmounts);
+			addedChests = lootHandler.spawnChests(maze, chestAmounts, isLootInHallways, isLootInDeadEnds, isLootInRooms);
 		} catch (TextException e) {
 			e.sendTextTo(sender);
 			return;

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
@@ -65,9 +65,6 @@ public class LootSpawnCommand extends ArgCommand {
 		if (!isLootInHallways && !isLootInDeadEnds && !isLootInRooms) {
 			isLootInHallways = isLootInDeadEnds = isLootInRooms = true;
 		}
-		sender.sendMessage("hall " + isLootInHallways);
-		sender.sendMessage("dead " + isLootInDeadEnds);
-		sender.sendMessage("room " + isLootInRooms);
 		try {
 			chestAmounts = deserializeLootChestPrefabs(argValues);
 			addedChests = lootHandler.spawnChests(maze, chestAmounts, isLootInHallways, isLootInDeadEnds, isLootInRooms);
@@ -75,6 +72,7 @@ public class LootSpawnCommand extends ArgCommand {
 			e.sendTextTo(sender);
 			return;
 		}
+		//TODO jsonfy
 		sender.sendMessage("Placed " + addedChests.size() + " chests");
 	}
 
@@ -119,6 +117,11 @@ public class LootSpawnCommand extends ArgCommand {
 	@Override
 	public List<String> getTabList(String[] stringArgs) {
 		List<String> tabList = super.getTabList(stringArgs);
+
+		if (!isAvailable) {
+			return tabList;
+		}
+		List<String> chestNames = lootHandler.getChestNames();
 
 		if (!tabList.isEmpty()) {
 			return tabList;

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/LootSpawnCommand.java
@@ -140,11 +140,11 @@ public class LootSpawnCommand extends ArgCommand {
 		} else if (MathUtil.isInt(tabbedArg)) {
 			factorString = tabbedArg + "*";
 		} else {
-			return MaterialUtil.getBlockNames();
+			return chestNames;
 		}
 
-		for (String blockName : MaterialUtil.getBlockNames()) {
-			tabList.add(factorString + blockName);
+		for (String chestName : chestNames) {
+			tabList.add(factorString + chestName);
 		}
 		return tabList;
 	}

--- a/src/main/java/me/gorgeousone/tangledmaze/maze/MazeProperty.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/maze/MazeProperty.java
@@ -11,7 +11,7 @@ public enum MazeProperty {
 	PATH_WIDTH(1, 64),
 	CURLINESS(3, 10),
 	ROOF_WIDTH(1, 64),
-	ROOM_COUNT(3, 100),
+	ROOM_COUNT(3, 100, 0),
 	ROOM_SIZE(15, 32, 3);
 	
 	private final int maxVal;

--- a/src/main/java/me/gorgeousone/tangledmaze/util/Direction.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/util/Direction.java
@@ -23,28 +23,37 @@ public enum Direction {
 		this.dirVec = dirVec;
 		this.face = face;
 	}
-	
+
+	public int getX() {
+		return dirVec.getX();
+	}
+
+	public int getZ(){
+		return dirVec.getZ();
+	}
+
+	public Vec2 getVec2() {
+		return dirVec.clone();
+	}
+
 	/**
 	 * Returns true if the direction's vector is pointing towards positive (with it's x and z coordinate)
 	 */
 	public boolean isPositive() {
 		return dirVec.getZ() >= 0 && dirVec.getX() >= 0;
 	}
-	
+
 	/**
 	 * Returns if the x coordinate of the direction's vector is not 0
 	 */
 	public boolean isCollinearX() {
 		return dirVec.getZ() == 0;
 	}
-	
+
 	public boolean isCollinearZ() {
 		return dirVec.getX() == 0;
 	}
-	
-	public Vec2 getVec2() {
-		return dirVec.clone();
-	}
+
 	
 	public Direction getOpposite() {
 		return values()[(ordinal() + 4) % values().length];


### PR DESCRIPTION
With the flags -deadends -rooms and -hallways you can now specify the places where the loot should appear. By default all 3 apply.
Example with loot in dead ends only:
*\*cough\* exits still get recognized as dead ends \*cough\**
![327248977-e80fa4ee-e82c-4937-9a31-91e1ed1edcac](https://github.com/GorgeousOne/Tangled-Maze-2/assets/27733909/8494f150-33dd-4fb9-9a27-8ae41213ef0f)
