### PR TITLE
Safer MC version parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ mvn install:install-file \
   -DgeneratePom=true
 ```
 
+`mvn clean package` to generate plugin jar in previously set directory

--- a/README.md
+++ b/README.md
@@ -16,9 +16,33 @@ For downloads & more information:
 
 ## Development
 
-To be able to compile the plugin with the [LootChest](https://www.spigotmc.org/resources/lootchest.61564/) dependency, you need to install the LootChest jar file in your local maven repository.
-You can do this by running the following commands in the directory where the LootChest.jar file is located:
-```shell
-mvn install:install-file -Dfile=<path/to/lootchest.jar> -DgroupId=fr.black_eyes.lootchest -DartifactId=lootchest -Dversion=2.5.0 -Dpackaging=jar
-mvn install:install-file -Dfile=<path/to/lootchest.jar> -DgroupId=fr.black_eyes.lootchest -DartifactId=fall_effect -Dversion=2.5.0 -Dpackaging=jar
+To compile the jar directly to the `server/plugins` folder, the pom.xml makes use of a user specific maven property defined in `~/.m2/settings.xml`:
+```xml
+<settings>
+  <profiles>
+    <profile>
+      <id>local-build</id>
+      <properties>
+        <plugin.output.dir>path/to/server/plugins</plugin.output.dir>
+      </properties>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>local-build</activeProfile>
+  </activeProfiles>
+</settings>
 ```
+
+To be able to compile the plugin with the [LootChest](https://www.spigotmc.org/resources/lootchest.61564/) dependency, you need to install the LootChest jar file in your local maven repository:
+
+```shell
+mvn install:install-file \
+  -Dfile=path/to/lootchest.jar \
+  -DgroupId=fr.black_eyes.lootchest \
+  -DartifactId=LootChest \
+  -Dversion=X.X.X \
+  -Dpackaging=jar \
+  -DgeneratePom=true
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>me.gorgeousone</groupId>
@@ -43,6 +43,15 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.4.2</version>
+				<configuration>
+					<outputDirectory>${plugin.output.dir}</outputDirectory>
+					<finalName>TangledMazePlus-v${project.version}</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 		<resources>
 			<resource>
@@ -79,7 +88,7 @@
 		<dependency>
 			<groupId>fr.black_eyes.lootchest</groupId>
 			<artifactId>LootChest</artifactId>
-			<version>2.5.0</version>
+			<version>2.5.8</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>me.gorgeousone</groupId>
 	<artifactId>tangledmaze</artifactId>
-	<version>3.1.0</version>
+	<version>3.1.1</version>
 	<packaging>jar</packaging>
 
 	<name>TangledMaze</name>
@@ -49,7 +49,7 @@
 				<version>3.4.2</version>
 				<configuration>
 					<outputDirectory>${plugin.output.dir}</outputDirectory>
-					<finalName>TangledMazePlus-v${project.version}</finalName>
+					<finalName>TangledMaze-v${project.version}</finalName>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/me/gorgeousone/tangledmaze/SessionHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/SessionHandler.java
@@ -5,11 +5,9 @@ import me.gorgeousone.tangledmaze.event.ClipDeleteEvent;
 import me.gorgeousone.tangledmaze.maze.MazeBackup;
 import me.gorgeousone.tangledmaze.maze.MazeSettings;
 import org.bukkit.Bukkit;
-import org.bukkit.event.Listener;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 /**

--- a/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/TangledMazePlugin.java
@@ -63,7 +63,7 @@ public final class TangledMazePlugin extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		instance = this;
-		configureAPI(getDescription().getVersion());
+		configureAPI(getDescription().getVersion(), getLogger());
 
 		sessionHandler = new SessionHandler();
 		toolHandler = new ToolHandler(sessionHandler);
@@ -95,8 +95,8 @@ public final class TangledMazePlugin extends JavaPlugin {
 	/**
 	 * Configures settings needed if the plugin is shaded into a plugin
 	 */
-	public static void configureAPI(String tangledMazeVersion) {
-		VersionUtil.setup(tangledMazeVersion);
+	public static void configureAPI(String tangledMazeVersion, Logger logger) {
+		VersionUtil.setup(tangledMazeVersion, logger);
 	}
 
 	/**

--- a/src/main/java/me/gorgeousone/tangledmaze/cmdframework/handler/CommandHandler.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/cmdframework/handler/CommandHandler.java
@@ -7,11 +7,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
-import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 

--- a/src/main/java/me/gorgeousone/tangledmaze/command/SolveMazeCommand.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/command/SolveMazeCommand.java
@@ -12,7 +12,6 @@ import me.gorgeousone.tangledmaze.render.RenderHandler;
 import me.gorgeousone.tangledmaze.render.RenderSession;
 import org.bukkit.command.CommandSender;
 
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/BlockCollection.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/BlockCollection.java
@@ -2,7 +2,6 @@ package me.gorgeousone.tangledmaze.generation;
 
 import me.gorgeousone.tangledmaze.util.BlockVec;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/MazeSolver.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/MazeSolver.java
@@ -6,11 +6,9 @@ import me.gorgeousone.tangledmaze.util.Direction;
 import me.gorgeousone.tangledmaze.util.Vec2;
 
 import java.util.ArrayDeque;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/generation/paving/Room.java
@@ -4,7 +4,6 @@ import me.gorgeousone.tangledmaze.generation.GridCell;
 import me.gorgeousone.tangledmaze.generation.GridMap;
 import me.gorgeousone.tangledmaze.util.Direction;
 import me.gorgeousone.tangledmaze.util.Vec2;
-import org.bukkit.block.BlockFace;
 
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/src/main/java/me/gorgeousone/tangledmaze/loot/UnbuildListener.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/loot/UnbuildListener.java
@@ -2,12 +2,8 @@ package me.gorgeousone.tangledmaze.loot;
 
 import me.gorgeousone.tangledmaze.event.MazeUnbuildEvent;
 import me.gorgeousone.tangledmaze.maze.MazePart;
-import me.gorgeousone.tangledmaze.util.text.TextException;
-import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-
-import java.util.logging.Level;
 
 public class UnbuildListener implements Listener {
 

--- a/src/main/java/me/gorgeousone/tangledmaze/render/RenderSession.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/render/RenderSession.java
@@ -1,6 +1,5 @@
 package me.gorgeousone.tangledmaze.render;
 
-import me.gorgeousone.tangledmaze.util.BlockVec;
 import me.gorgeousone.tangledmaze.util.Vec2;
 import me.gorgeousone.tangledmaze.util.blocktype.BlockType;
 import org.bukkit.Bukkit;

--- a/src/main/java/me/gorgeousone/tangledmaze/updatecheck/UpdateCheck.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/updatecheck/UpdateCheck.java
@@ -46,6 +46,7 @@ public class UpdateCheck {
 		InputStream inputStream = new URL(updateInfoPasteUrl).openStream();
 		Scanner scanner = new Scanner(inputStream);
 		UpdateInfo latestUpdate = new UpdateInfo(scanner.nextLine(), resourceName, resourceId);
+		scanner.close();
 		
 		if (VersionUtil.PLUGIN_VERSION.isBelow(latestUpdate.getVersion())) {
 			return latestUpdate;

--- a/src/main/java/me/gorgeousone/tangledmaze/util/BlockUtil.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/util/BlockUtil.java
@@ -3,9 +3,7 @@ package me.gorgeousone.tangledmaze.util;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/src/main/java/me/gorgeousone/tangledmaze/util/Version.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/util/Version.java
@@ -7,23 +7,30 @@ public class Version {
 	int major;
 	int minor;
 	int patch;
-	
+
+	public Version(int major, int minor, int patch) {
+		this.major = major;
+		this.minor = minor;
+		this.patch = patch;
+	}
+
 	public Version(String versionString) {
 		this(versionString, "\\.");
 	}
 	
 	public Version(String versionString, String delimiter) {
+		parseUnsafe(versionString, delimiter);
+	}
+
+	private void parseUnsafe(String versionString, String delimiter) {
 		String[] split = versionString.split(delimiter);
 		major = Integer.parseInt(split[0]);
+
 		if (split.length > 1) {
 			minor = Integer.parseInt(split[1]);
-		} else {
-			minor = 0;
 		}
 		if (split.length > 2) {
 			patch = Integer.parseInt(split[2]);
-		} else {
-			patch = 0;
 		}
 	}
 	

--- a/src/main/java/me/gorgeousone/tangledmaze/util/VersionUtil.java
+++ b/src/main/java/me/gorgeousone/tangledmaze/util/VersionUtil.java
@@ -1,27 +1,57 @@
 package me.gorgeousone.tangledmaze.util;
 
-import org.bukkit.Bukkit;
-import org.bukkit.plugin.java.JavaPlugin;
+import java.util.logging.Logger;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
+import org.bukkit.Bukkit;
 
 public final class VersionUtil {
-	
+
 	public static Version PLUGIN_VERSION;
 	public static Version SERVER_VERSION;
 	public static boolean IS_LEGACY_SERVER;
-	
-	private VersionUtil() {}
 
-	public static void setup(String tangledMazeVersion) {
+	private VersionUtil() {
+	}
+
+	public static void setup(String tangledMazeVersion, Logger logger) {
 		PLUGIN_VERSION = new Version(tangledMazeVersion);
-		SERVER_VERSION = new Version(getServerVersionString());
+		SERVER_VERSION = parseMcVersionSafe(getServerVersionString(), logger);
 		IS_LEGACY_SERVER = SERVER_VERSION.isBelow(new Version("1.13.0"));
+		logger.info("    Found MC version: " + SERVER_VERSION);
 	}
 
 	public static String getServerVersionString() {
 		return Bukkit.getBukkitVersion().split("-")[0];
 	}
+
+	public static Version parseMcVersionSafe(String versionString, Logger logger) {
+		int major = 1;
+		int minor = 13;
+		int patch = 0;
+
+		boolean abort = false;
+		String[] split = versionString.split("\\.");
+
+		try {
+			major = Integer.parseInt(split[0]);
+		} catch (Exception e) {
+			logger.warning("Could not find MC major version. Assuming aquatic update (1.13) or later.");
+			abort = true;
+		}
+		if (!abort && split.length > 1) {
+			try {
+				minor = Integer.parseInt(split[1]);
+			} catch (Exception e) {
+				logger.warning("Could not parse MC minor version. Assuming 0.");
+				abort = true;
+			}
+		}
+		if (!abort && split.length > 2) {
+			try {
+				patch = Integer.parseInt(split[2]);
+			} catch (Exception ignored) {}
+		}
+		return new Version(major, minor, patch);
+	}
+
 }

--- a/src/test/java/GridCellTest.java
+++ b/src/test/java/GridCellTest.java
@@ -1,0 +1,31 @@
+import me.gorgeousone.tangledmaze.generation.GridCell;
+import me.gorgeousone.tangledmaze.util.Direction;
+import me.gorgeousone.tangledmaze.util.Vec2;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GridCellTest {
+
+	@Test
+	void testGridCellWalls() {
+		GridCell cell = new GridCell(new Vec2(0, 0), new Vec2(3, 4), null);
+		List<Vec2> wallsPositiveX = cell.getWalls(Direction.EAST);
+		System.out.println(wallsPositiveX);
+		assertTrue(wallsPositiveX.contains(new Vec2(2, 0)));
+		assertTrue(wallsPositiveX.contains(new Vec2(2, 1)));
+		assertTrue(wallsPositiveX.contains(new Vec2(2, 2)));
+		assertTrue(wallsPositiveX.contains(new Vec2(2, 3)));
+		assertEquals(wallsPositiveX.size(), 4);
+
+		List<Vec2> wallsNegativeZ = cell.getWalls(Direction.NORTH);
+		System.out.println(wallsNegativeZ);
+		assertTrue(wallsNegativeZ.contains(new Vec2(0, 0)));
+		assertTrue(wallsNegativeZ.contains(new Vec2(1, 0)));
+		assertTrue(wallsNegativeZ.contains(new Vec2(2, 0)));
+		assertEquals(wallsNegativeZ.size(), 3);
+	}
+}

--- a/src/test/java/VersionTest.java
+++ b/src/test/java/VersionTest.java
@@ -1,4 +1,6 @@
 import me.gorgeousone.tangledmaze.util.Version;
+import me.gorgeousone.tangledmaze.util.VersionUtil;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -9,6 +11,7 @@ public class VersionTest {
 	
 	@Test
 	void testVersionRegex() {
+		assertEquals(VersionUtil.parseMcVersionSafe("26.2.build.48", null), new Version(26, 2, 0));
 
 		Version v100 = new Version("1.0.0");
 		Version v101 = new Version("1.0.1");

--- a/src/test/java/VersionTest.java
+++ b/src/test/java/VersionTest.java
@@ -1,0 +1,29 @@
+import me.gorgeousone.tangledmaze.util.Version;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VersionTest {
+	
+	@Test
+	void testVersionRegex() {
+
+		Version v100 = new Version("1.0.0");
+		Version v101 = new Version("1.0.1");
+		Version v110 = new Version("1.1.0");
+		Version v200 = new Version("2.0.0");
+		Version v20 = new Version("2.0");
+
+		assertTrue(v100.isBelow(v101));
+		assertTrue(v100.isBelow(v110));
+		assertTrue(v100.isBelow(v200));
+		assertTrue(v100.isBelow(v20));
+
+		assertFalse(v101.isBelow(v100));
+		assertFalse(v110.isBelow(v100));
+		assertFalse(v200.isBelow(v100));
+		assertFalse(v20.isBelow(v100));
+	}
+}


### PR DESCRIPTION
Added more fallbacks when parsing server's MC version string to avoid unnecessary crashes.
If a version string is missing minor or patch number, the code will falback to `0`. `26.2.build.48` might be parsed to `26.2.0`.
If no major version can be parsed at all, `1.13` or later will be assumed, since this is the only important information for the plugin regarding how to handle materials.